### PR TITLE
chore: pin GitHub actions to specific commit SHA

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   automerge:
-    uses: oclif/github-workflows/.github/workflows/automerge.yml@main
+    uses: oclif/github-workflows/.github/workflows/automerge.yml@56d34995157cd6b3376597d9d2feb1e10af998bd # main
     secrets: inherit

--- a/.github/workflows/failureNotifications.yml
+++ b/.github/workflows/failureNotifications.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Announce Failure
         id: slack
-        uses: slackapi/slack-github-action@v1.21.0
+        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # v1.21.0
         env:
           # for non-CLI-team-owned plugins, you can send this anywhere you like
           SLACK_WEBHOOK_URL: ${{ secrets.CLI_ALERTS_SLACK_WEBHOOK }}

--- a/.github/workflows/manualRelease.yml
+++ b/.github/workflows/manualRelease.yml
@@ -7,12 +7,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
       - name: Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@d360fad3a42feca6462f72c97c165d60a02d4bf2
+        uses: TriPSs/conventional-changelog-action@d360fad3a42feca6462f72c97c165d60a02d4bf2 # d360fad3a42feca6462f72c97c165d60a02d4bf2
         # overriding some of the basic behaviors to just get the changelog
         with:
           git-user-name: svc-cli-bot
@@ -22,13 +22,13 @@ jobs:
           # always do the release, even if there are no semantic commits
           skip-on-empty: false
           tag-prefix: ''
-      - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
+      - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216 # 2192e246737701f108a4571462b76c75e7376216
         id: packageVersion
         with:
           path: 'package.json'
           prop_path: 'version'
       - name: Create Github Release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/notify-slack-on-pr-open.yml
+++ b/.github/workflows/notify-slack-on-pr-open.yml
@@ -20,4 +20,4 @@ jobs:
         PULL_REQUEST_REPO: ${{ github.event.pull_request.head.repo.name }}
         PULL_REQUEST_TITLE : ${{ github.event.pull_request.title }}
         PULL_REQUEST_URL : ${{ github.event.pull_request.html_url }}
-      uses: salesforcecli/github-workflows/.github/actions/prNotification@main
+      uses: salesforcecli/github-workflows/.github/actions/prNotification@805971e8a839922a04ee328b6bae60894bfc81c4 # main

--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -20,13 +20,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
           token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION

To proactively limit the impact of a compromised dependency, GitHub recommends that workflows pin dependency versions to a specific commit SHA. This will prevent malicious code added to a new or updated branch or tag from being automatically used.

In GitHub there’s a setting to “Require actions to be pinned to a full-length commit SHA” and we intend to enable this setting soon.

The changes in this PR were created using the [`pin-github-action`](https://github.com/mheap/pin-github-action) tool.


[GitHub blog post](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>