### PR TITLE
fix: deprecate @gr4vy/cli in favour of the Go CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 Gr4vy CLI
 =================
 
+> [!WARNING]
+> **`@gr4vy/cli` is deprecated and no longer maintained.**
+> The Gr4vy CLI has been rewritten in Go and is no longer published to npm.
+> Install the new CLI instead:
+>
+> ```sh
+> brew install gr4vy/tap/gr4vy
+> ```
+>
+> See https://github.com/gr4vy/gr4vy-cli for documentation. This npm package will
+> not receive further updates.
+
 The Gr4vy CLI is a useful tool for developers to quickly generate tokens, 
 query data, and perform basic API manipulation. 
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -19,6 +19,11 @@ export abstract class BaseCommand extends Command {
 
   public async init(): Promise<void> {
     await super.init();
+    process.stderr.write(
+      "⚠️  @gr4vy/cli is deprecated and no longer maintained. " +
+        "Install the new Go CLI instead: brew install gr4vy/tap/gr4vy " +
+        "(https://github.com/gr4vy/gr4vy-cli)\n"
+    );
     this.load();
   }
 }


### PR DESCRIPTION
Marks the npm `@gr4vy/cli` package as deprecated ahead of the Go rewrite (#50).

## Changes
- **README**: a deprecation banner (above the `<!-- toc -->` marker, so `oclif readme` won't overwrite it) pointing users to `brew install gr4vy/tap/gr4vy`.
- **`src/base.ts`**: a one-line stderr warning printed on every invocation.

## Sequence (important)
1. **Merge this PR first** (while `main` is still the TypeScript project). The push-to-main release flow (`auto shipit`) publishes a final, deprecated npm version carrying the banner + runtime warning.
2. Run the registry-level deprecation (needs npm publish rights):
   ```sh
   npm deprecate '@gr4vy/cli@*' "Rewritten in Go — see https://github.com/gr4vy/gr4vy-cli. Install: brew install gr4vy/tap/gr4vy"
   ```
3. Then merge the Go rewrite (#50), which replaces `main`.

The TypeScript source is preserved on the **`legacy`** branch (frozen at the pre-rewrite commit) for any future hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)