### PR TITLE
ci: auto-merge the release-please PR

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,42 @@
+# Auto-approve and auto-merge the release-please PR, mirroring how the gr4vy
+# SDK repos auto-merge their bot PRs. Once CI passes, the "chore(main): release
+# X.Y.Z" PR merges itself, which tags the version and triggers goreleaser.
+name: auto-merge release
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      # Approve the release PR so the required-review rule is satisfied. The
+      # default GITHUB_TOKEN approves as github-actions[bot] — a distinct
+      # identity from the PR author (gr4vy-code), so it counts as a review.
+      - name: Approve the release-please PR
+        if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'release-please--') }}
+        uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
+
+      # Merge it once it's mergeable (required checks green + the approval
+      # above). Scoped to the release PR via its label; squash to match the
+      # SDKs. pascalgn merges via the API, so it respects branch protection.
+      - name: Auto-merge the release-please PR
+        uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          MERGE_LABELS: "autorelease: pending"
+          MERGE_REQUIRED_APPROVALS: "0"
+          MERGE_METHOD: squash
+          MERGE_COMMIT_MESSAGE: pull-request-title
+          MERGE_DELETE_BRANCH: false
+          MERGE_FORKS: false
+          MERGE_RETRY_SLEEP: "30000"


### PR DESCRIPTION
Makes the `chore(main): release X.Y.Z` PR merge itself once CI is green — matching how the gr4vy SDK repos auto-merge their bot PRs — so cutting a release is hands-off after the regular PRs land.

## How it works (`.github/workflows/auto-merge-release.yml`)
- **`hmarr/auto-approve-action`** approves the release PR. It approves as `github-actions[bot]`, a different identity from the PR author (`gr4vy-code`), so it satisfies the required-review rule. Gated on the `release-please--…` head branch.
- **`pascalgn/automerge-action`** squash-merges the PR once it's mergeable (required checks green + that approval). Scoped to the `autorelease: pending` label so **only** the release PR is affected. It merges via the API, so branch protection is still enforced.
- Same pinned action SHAs the SDK repos use. Triggers on `pull_request`, `pull_request_review`, and `check_suite: completed` so it re-evaluates and merges when `ci-complete` finishes.

The merge then tags `vX.Y.Z`, which fires the existing goreleaser release (binaries + Homebrew + Scoop).

## Caveat to confirm
This assumes branch protection accepts a **bot approval** for the required review. If the ruleset requires a human/CODEOWNER approval, the auto-approve won't satisfy it — tell me and I'll switch the approval to a PAT-based identity or adjust. (The SDK repos run exactly this, so it should match.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)