### PR TITLE
docs: add Scoop (Windows) install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ with the SDK automatically.
 brew install gr4vy/tap/gr4vy
 ```
 
+### Scoop (Windows)
+
+```powershell
+scoop bucket add gr4vy https://github.com/gr4vy/scoop-bucket
+scoop install gr4vy
+```
+
 ### Go
 
 ```sh


### PR DESCRIPTION
Adds a Scoop section to the README's Install block, alongside Homebrew/Go/binaries, now that the `gr4vy/scoop-bucket` exists and the v1.0.0 manifest is published:

```powershell
scoop bucket add gr4vy https://github.com/gr4vy/scoop-bucket
scoop install gr4vy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)