### PR TITLE
docs: autogenerated command reference + output/completion docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
       - name: generation is up to date
         run: |
           go generate ./...
-          if ! git diff --quiet -- internal/commands/generated; then
-            echo "::error::generated commands are stale; run 'go generate ./...' and commit"
-            git --no-pager diff -- internal/commands/generated | head -100
+          if ! git diff --quiet -- internal/commands/generated docs; then
+            echo "::error::generated commands/docs are stale; run 'go generate ./...' and commit"
+            git --no-pager diff --stat -- internal/commands/generated docs
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build gen test lint fmt vet tidy e2e install
+.PHONY: build gen docs test lint fmt vet tidy e2e install
 
 # Build the binary with version metadata.
 VERSION ?= dev
@@ -9,9 +9,13 @@ LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.dat
 build:
 	go build -ldflags "$(LDFLAGS)" -o gr4vy .
 
-# Regenerate the command surface from the gr4vy-go SDK types.
+# Regenerate the command surface (and docs) from the gr4vy-go SDK types.
 gen:
 	go generate ./...
+
+# Regenerate just the Markdown command reference under docs/.
+docs:
+	go run ./internal/gendocs
 
 # Bump gr4vy-go to its latest release, then regenerate (mirrors the regen CI job).
 gen-refresh:

--- a/README.md
+++ b/README.md
@@ -122,8 +122,39 @@ gr4vy embed 1299 USD --checkout-session # also creates a checkout session
 
 ## Output
 
-`-o, --output json|yaml|table` (defaults to `table` on a TTY, `json` otherwise).
+`-o, --output json|yaml|table` (defaults to `table` on a TTY, `json` otherwise; also
+settable via `GR4VY_OUTPUT`). `--compact` emits single-line JSON for piping to `jq`.
 Lists accept `--limit` and `--cursor`; the `next_cursor` is returned for paging.
+
+## Command reference
+
+Every command is documented under [`docs/`](docs/gr4vy.md) — one page per command with its
+arguments, flags, and the SDK operation it calls. The pages are generated from the CLI
+itself (`make docs`) and stay in sync with the command surface. You can also explore
+interactively:
+
+```sh
+gr4vy --help
+gr4vy transactions --help
+gr4vy transactions list --help
+```
+
+## Shell completion
+
+Completion is built in for bash, zsh, fish, and PowerShell. Generate a script with
+`gr4vy completion <shell>`:
+
+```sh
+# zsh
+gr4vy completion zsh > "${fpath[1]}/_gr4vy"
+# bash
+gr4vy completion bash > /usr/local/etc/bash_completion.d/gr4vy
+# fish
+gr4vy completion fish > ~/.config/fish/completions/gr4vy.fish
+```
+
+Run `gr4vy completion --help` for per-shell setup. Flags with fixed choices (e.g.
+`token --scope`) complete their values.
 
 ## How it stays up to date
 

--- a/docs/gr4vy.md
+++ b/docs/gr4vy.md
@@ -1,0 +1,53 @@
+## gr4vy
+
+The Gr4vy CLI
+
+### Synopsis
+
+gr4vy is the command-line interface for the Gr4vy payment orchestration platform.
+
+### Options
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+  -h, --help                         help for gr4vy
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy account-updater](gr4vy_account-updater.md)	 - Manage account-updater
+* [gr4vy audit-logs](gr4vy_audit-logs.md)	 - Manage audit-logs
+* [gr4vy buyers](gr4vy_buyers.md)	 - Manage buyers
+* [gr4vy card-scheme-definitions](gr4vy_card-scheme-definitions.md)	 - Manage card-scheme-definitions
+* [gr4vy checkout-sessions](gr4vy_checkout-sessions.md)	 - Manage checkout-sessions
+* [gr4vy config](gr4vy_config.md)	 - Manage configuration profiles
+* [gr4vy digital-wallets](gr4vy_digital-wallets.md)	 - Manage digital-wallets
+* [gr4vy embed](gr4vy_embed.md)	 - Generate an Embed token for the checkout form
+* [gr4vy gift-cards](gr4vy_gift-cards.md)	 - Manage gift-cards
+* [gr4vy init](gr4vy_init.md)	 - Create your first profile interactively
+* [gr4vy login](gr4vy_login.md)	 - Log in with email and password
+* [gr4vy logout](gr4vy_logout.md)	 - Log out and clear stored session tokens
+* [gr4vy merchant-accounts](gr4vy_merchant-accounts.md)	 - Manage merchant-accounts
+* [gr4vy payment-links](gr4vy_payment-links.md)	 - Manage payment-links
+* [gr4vy payment-methods](gr4vy_payment-methods.md)	 - Manage payment-methods
+* [gr4vy payment-options](gr4vy_payment-options.md)	 - Manage payment-options
+* [gr4vy payment-service-definitions](gr4vy_payment-service-definitions.md)	 - Manage payment-service-definitions
+* [gr4vy payment-services](gr4vy_payment-services.md)	 - Manage payment-services
+* [gr4vy payouts](gr4vy_payouts.md)	 - Manage payouts
+* [gr4vy refunds](gr4vy_refunds.md)	 - Manage refunds
+* [gr4vy report-executions](gr4vy_report-executions.md)	 - Manage report-executions
+* [gr4vy reports](gr4vy_reports.md)	 - Manage reports
+* [gr4vy three-ds-scenarios](gr4vy_three-ds-scenarios.md)	 - Manage three-ds-scenarios
+* [gr4vy token](gr4vy_token.md)	 - Generate a server-to-server API access token (JWT)
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+* [gr4vy version](gr4vy_version.md)	 - Print the CLI version
+

--- a/docs/gr4vy_account-updater.md
+++ b/docs/gr4vy_account-updater.md
@@ -1,0 +1,30 @@
+## gr4vy account-updater
+
+Manage account-updater
+
+### Options
+
+```
+  -h, --help   help for account-updater
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy account-updater jobs](gr4vy_account-updater_jobs.md)	 - Manage account-updater jobs
+

--- a/docs/gr4vy_account-updater_jobs.md
+++ b/docs/gr4vy_account-updater_jobs.md
@@ -1,0 +1,30 @@
+## gr4vy account-updater jobs
+
+Manage account-updater jobs
+
+### Options
+
+```
+  -h, --help   help for jobs
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy account-updater](gr4vy_account-updater.md)	 - Manage account-updater
+* [gr4vy account-updater jobs create](gr4vy_account-updater_jobs_create.md)	 - Create account updater job
+

--- a/docs/gr4vy_account-updater_jobs_create.md
+++ b/docs/gr4vy_account-updater_jobs_create.md
@@ -1,0 +1,40 @@
+## gr4vy account-updater jobs create
+
+Create account updater job
+
+### Synopsis
+
+Create account updater job
+
+Schedule one or more stored cards for an account update.
+
+```
+gr4vy account-updater jobs create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (AccountUpdaterJobCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy account-updater jobs](gr4vy_account-updater_jobs.md)	 - Manage account-updater jobs
+

--- a/docs/gr4vy_audit-logs.md
+++ b/docs/gr4vy_audit-logs.md
@@ -1,0 +1,30 @@
+## gr4vy audit-logs
+
+Manage audit-logs
+
+### Options
+
+```
+  -h, --help   help for audit-logs
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy audit-logs list](gr4vy_audit-logs_list.md)	 - List audit log entries
+

--- a/docs/gr4vy_audit-logs_list.md
+++ b/docs/gr4vy_audit-logs_list.md
@@ -1,0 +1,44 @@
+## gr4vy audit-logs list
+
+List audit log entries
+
+### Synopsis
+
+List audit log entries
+
+Returns a list of activity by dashboard users.
+
+```
+gr4vy audit-logs list [flags]
+```
+
+### Options
+
+```
+      --action string          action parameter
+      --cursor string          pagination cursor
+  -h, --help                   help for list
+      --limit int              maximum number of items to return
+      --resource-type string   resource-type parameter
+      --user-id string         user-id parameter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy audit-logs](gr4vy_audit-logs.md)	 - Manage audit-logs
+

--- a/docs/gr4vy_buyers.md
+++ b/docs/gr4vy_buyers.md
@@ -1,0 +1,37 @@
+## gr4vy buyers
+
+Manage buyers
+
+### Options
+
+```
+  -h, --help   help for buyers
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy buyers create](gr4vy_buyers_create.md)	 - Add a buyer
+* [gr4vy buyers delete](gr4vy_buyers_delete.md)	 - Delete a buyer
+* [gr4vy buyers get](gr4vy_buyers_get.md)	 - Get a buyer
+* [gr4vy buyers gift-cards](gr4vy_buyers_gift-cards.md)	 - Manage buyers gift-cards
+* [gr4vy buyers list](gr4vy_buyers_list.md)	 - List all buyers
+* [gr4vy buyers payment-methods](gr4vy_buyers_payment-methods.md)	 - Manage buyers payment-methods
+* [gr4vy buyers shipping-details](gr4vy_buyers_shipping-details.md)	 - Manage buyers shipping-details
+* [gr4vy buyers update](gr4vy_buyers_update.md)	 - Update a buyer
+

--- a/docs/gr4vy_buyers_create.md
+++ b/docs/gr4vy_buyers_create.md
@@ -1,0 +1,40 @@
+## gr4vy buyers create
+
+Add a buyer
+
+### Synopsis
+
+Add a buyer
+
+Create a new buyer record.
+
+```
+gr4vy buyers create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (BuyerCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers](gr4vy_buyers.md)	 - Manage buyers
+

--- a/docs/gr4vy_buyers_delete.md
+++ b/docs/gr4vy_buyers_delete.md
@@ -1,0 +1,39 @@
+## gr4vy buyers delete
+
+Delete a buyer
+
+### Synopsis
+
+Delete a buyer
+
+Permanently removes a buyer record.
+
+```
+gr4vy buyers delete <buyer-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers](gr4vy_buyers.md)	 - Manage buyers
+

--- a/docs/gr4vy_buyers_get.md
+++ b/docs/gr4vy_buyers_get.md
@@ -1,0 +1,39 @@
+## gr4vy buyers get
+
+Get a buyer
+
+### Synopsis
+
+Get a buyer
+
+Fetches a buyer by its ID.
+
+```
+gr4vy buyers get <buyer-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers](gr4vy_buyers.md)	 - Manage buyers
+

--- a/docs/gr4vy_buyers_gift-cards.md
+++ b/docs/gr4vy_buyers_gift-cards.md
@@ -1,0 +1,30 @@
+## gr4vy buyers gift-cards
+
+Manage buyers gift-cards
+
+### Options
+
+```
+  -h, --help   help for gift-cards
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers](gr4vy_buyers.md)	 - Manage buyers
+* [gr4vy buyers gift-cards list](gr4vy_buyers_gift-cards_list.md)	 - List gift cards for a buyer
+

--- a/docs/gr4vy_buyers_gift-cards_list.md
+++ b/docs/gr4vy_buyers_gift-cards_list.md
@@ -1,0 +1,43 @@
+## gr4vy buyers gift-cards list
+
+List gift cards for a buyer
+
+### Synopsis
+
+List gift cards for a buyer
+
+List all the stored gift cards for a specific buyer.
+
+```
+gr4vy buyers gift-cards list [flags]
+```
+
+### Options
+
+```
+      --buyer-external-identifier string   buyer-external-identifier parameter
+      --buyer-id string                    buyer-id parameter
+  -h, --help                               help for list
+      --order-by string                    order-by parameter
+      --sort-by string                     sort-by parameter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers gift-cards](gr4vy_buyers_gift-cards.md)	 - Manage buyers gift-cards
+

--- a/docs/gr4vy_buyers_list.md
+++ b/docs/gr4vy_buyers_list.md
@@ -1,0 +1,43 @@
+## gr4vy buyers list
+
+List all buyers
+
+### Synopsis
+
+List all buyers
+
+List all buyers or search for a specific buyer.
+
+```
+gr4vy buyers list [flags]
+```
+
+### Options
+
+```
+      --cursor string                pagination cursor
+      --external-identifier string   external-identifier parameter
+  -h, --help                         help for list
+      --limit int                    maximum number of items to return
+      --search string                free-text search filter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers](gr4vy_buyers.md)	 - Manage buyers
+

--- a/docs/gr4vy_buyers_payment-methods.md
+++ b/docs/gr4vy_buyers_payment-methods.md
@@ -1,0 +1,30 @@
+## gr4vy buyers payment-methods
+
+Manage buyers payment-methods
+
+### Options
+
+```
+  -h, --help   help for payment-methods
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers](gr4vy_buyers.md)	 - Manage buyers
+* [gr4vy buyers payment-methods list](gr4vy_buyers_payment-methods_list.md)	 - List payment methods for a buyer
+

--- a/docs/gr4vy_buyers_payment-methods_list.md
+++ b/docs/gr4vy_buyers_payment-methods_list.md
@@ -1,0 +1,45 @@
+## gr4vy buyers payment-methods list
+
+List payment methods for a buyer
+
+### Synopsis
+
+List payment methods for a buyer
+
+List all the stored payment methods for a specific buyer.
+
+```
+gr4vy buyers payment-methods list [flags]
+```
+
+### Options
+
+```
+      --buyer-external-identifier string   buyer-external-identifier parameter
+      --buyer-id string                    buyer-id parameter
+      --country string                     country parameter
+      --currency string                    currency parameter
+  -h, --help                               help for list
+      --order-by string                    order-by parameter
+      --sort-by string                     sort-by parameter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers payment-methods](gr4vy_buyers_payment-methods.md)	 - Manage buyers payment-methods
+

--- a/docs/gr4vy_buyers_shipping-details.md
+++ b/docs/gr4vy_buyers_shipping-details.md
@@ -1,0 +1,34 @@
+## gr4vy buyers shipping-details
+
+Manage buyers shipping-details
+
+### Options
+
+```
+  -h, --help   help for shipping-details
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers](gr4vy_buyers.md)	 - Manage buyers
+* [gr4vy buyers shipping-details create](gr4vy_buyers_shipping-details_create.md)	 - Add buyer shipping details
+* [gr4vy buyers shipping-details delete](gr4vy_buyers_shipping-details_delete.md)	 - Delete a buyer's shipping details
+* [gr4vy buyers shipping-details get](gr4vy_buyers_shipping-details_get.md)	 - Get buyer shipping details
+* [gr4vy buyers shipping-details list](gr4vy_buyers_shipping-details_list.md)	 - List a buyer's shipping details
+* [gr4vy buyers shipping-details update](gr4vy_buyers_shipping-details_update.md)	 - Update a buyer's shipping details
+

--- a/docs/gr4vy_buyers_shipping-details_create.md
+++ b/docs/gr4vy_buyers_shipping-details_create.md
@@ -1,0 +1,40 @@
+## gr4vy buyers shipping-details create
+
+Add buyer shipping details
+
+### Synopsis
+
+Add buyer shipping details
+
+Associate shipping details to a buyer.
+
+```
+gr4vy buyers shipping-details create <buyer-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (ShippingDetailsCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers shipping-details](gr4vy_buyers_shipping-details.md)	 - Manage buyers shipping-details
+

--- a/docs/gr4vy_buyers_shipping-details_delete.md
+++ b/docs/gr4vy_buyers_shipping-details_delete.md
@@ -1,0 +1,39 @@
+## gr4vy buyers shipping-details delete
+
+Delete a buyer's shipping details
+
+### Synopsis
+
+Delete a buyer's shipping details
+
+Delete the shipping details associated to a specific buyer.
+
+```
+gr4vy buyers shipping-details delete <buyer-id> <shipping-details-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers shipping-details](gr4vy_buyers_shipping-details.md)	 - Manage buyers shipping-details
+

--- a/docs/gr4vy_buyers_shipping-details_get.md
+++ b/docs/gr4vy_buyers_shipping-details_get.md
@@ -1,0 +1,39 @@
+## gr4vy buyers shipping-details get
+
+Get buyer shipping details
+
+### Synopsis
+
+Get buyer shipping details
+
+Get a buyer's shipping details.
+
+```
+gr4vy buyers shipping-details get <buyer-id> <shipping-details-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers shipping-details](gr4vy_buyers_shipping-details.md)	 - Manage buyers shipping-details
+

--- a/docs/gr4vy_buyers_shipping-details_list.md
+++ b/docs/gr4vy_buyers_shipping-details_list.md
@@ -1,0 +1,39 @@
+## gr4vy buyers shipping-details list
+
+List a buyer's shipping details
+
+### Synopsis
+
+List a buyer's shipping details
+
+List all the shipping details associated to a specific buyer.
+
+```
+gr4vy buyers shipping-details list <buyer-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers shipping-details](gr4vy_buyers_shipping-details.md)	 - Manage buyers shipping-details
+

--- a/docs/gr4vy_buyers_shipping-details_update.md
+++ b/docs/gr4vy_buyers_shipping-details_update.md
@@ -1,0 +1,40 @@
+## gr4vy buyers shipping-details update
+
+Update a buyer's shipping details
+
+### Synopsis
+
+Update a buyer's shipping details
+
+Update the shipping details associated to a specific buyer.
+
+```
+gr4vy buyers shipping-details update <buyer-id> <shipping-details-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (ShippingDetailsUpdate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers shipping-details](gr4vy_buyers_shipping-details.md)	 - Manage buyers shipping-details
+

--- a/docs/gr4vy_buyers_update.md
+++ b/docs/gr4vy_buyers_update.md
@@ -1,0 +1,40 @@
+## gr4vy buyers update
+
+Update a buyer
+
+### Synopsis
+
+Update a buyer
+
+Updates a buyer record.
+
+```
+gr4vy buyers update <buyer-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (BuyerUpdate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy buyers](gr4vy_buyers.md)	 - Manage buyers
+

--- a/docs/gr4vy_card-scheme-definitions.md
+++ b/docs/gr4vy_card-scheme-definitions.md
@@ -1,0 +1,30 @@
+## gr4vy card-scheme-definitions
+
+Manage card-scheme-definitions
+
+### Options
+
+```
+  -h, --help   help for card-scheme-definitions
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy card-scheme-definitions list](gr4vy_card-scheme-definitions_list.md)	 - List card scheme definitions
+

--- a/docs/gr4vy_card-scheme-definitions_list.md
+++ b/docs/gr4vy_card-scheme-definitions_list.md
@@ -1,0 +1,39 @@
+## gr4vy card-scheme-definitions list
+
+List card scheme definitions
+
+### Synopsis
+
+List card scheme definitions
+
+Fetch a list of the definitions of each card scheme.
+
+```
+gr4vy card-scheme-definitions list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy card-scheme-definitions](gr4vy_card-scheme-definitions.md)	 - Manage card-scheme-definitions
+

--- a/docs/gr4vy_checkout-sessions.md
+++ b/docs/gr4vy_checkout-sessions.md
@@ -1,0 +1,33 @@
+## gr4vy checkout-sessions
+
+Manage checkout-sessions
+
+### Options
+
+```
+  -h, --help   help for checkout-sessions
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy checkout-sessions create](gr4vy_checkout-sessions_create.md)	 - Create checkout session
+* [gr4vy checkout-sessions delete](gr4vy_checkout-sessions_delete.md)	 - Delete checkout session
+* [gr4vy checkout-sessions get](gr4vy_checkout-sessions_get.md)	 - Get checkout session
+* [gr4vy checkout-sessions update](gr4vy_checkout-sessions_update.md)	 - Update checkout session
+

--- a/docs/gr4vy_checkout-sessions_create.md
+++ b/docs/gr4vy_checkout-sessions_create.md
@@ -1,0 +1,40 @@
+## gr4vy checkout-sessions create
+
+Create checkout session
+
+### Synopsis
+
+Create checkout session
+
+Create a new checkout session.
+
+```
+gr4vy checkout-sessions create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (CheckoutSessionCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy checkout-sessions](gr4vy_checkout-sessions.md)	 - Manage checkout-sessions
+

--- a/docs/gr4vy_checkout-sessions_delete.md
+++ b/docs/gr4vy_checkout-sessions_delete.md
@@ -1,0 +1,39 @@
+## gr4vy checkout-sessions delete
+
+Delete checkout session
+
+### Synopsis
+
+Delete checkout session
+
+Delete a checkout session and all of its (PCI) data.
+
+```
+gr4vy checkout-sessions delete <session-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy checkout-sessions](gr4vy_checkout-sessions.md)	 - Manage checkout-sessions
+

--- a/docs/gr4vy_checkout-sessions_get.md
+++ b/docs/gr4vy_checkout-sessions_get.md
@@ -1,0 +1,39 @@
+## gr4vy checkout-sessions get
+
+Get checkout session
+
+### Synopsis
+
+Get checkout session
+
+Retrieve the information stored on a checkout session.
+
+```
+gr4vy checkout-sessions get <session-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy checkout-sessions](gr4vy_checkout-sessions.md)	 - Manage checkout-sessions
+

--- a/docs/gr4vy_checkout-sessions_update.md
+++ b/docs/gr4vy_checkout-sessions_update.md
@@ -1,0 +1,40 @@
+## gr4vy checkout-sessions update
+
+Update checkout session
+
+### Synopsis
+
+Update checkout session
+
+Update the information stored on a checkout session.
+
+```
+gr4vy checkout-sessions update <session-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (CheckoutSessionCreate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy checkout-sessions](gr4vy_checkout-sessions.md)	 - Manage checkout-sessions
+

--- a/docs/gr4vy_config.md
+++ b/docs/gr4vy_config.md
@@ -1,0 +1,37 @@
+## gr4vy config
+
+Manage configuration profiles
+
+### Options
+
+```
+  -h, --help   help for config
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy config add](gr4vy_config_add.md)	 - Add or update a profile
+* [gr4vy config import](gr4vy_config_import.md)	 - Import the legacy ~/.gr4vyrc.json into a profile
+* [gr4vy config key](gr4vy_config_key.md)	 - Print the active profile's private key (PEM)
+* [gr4vy config list](gr4vy_config_list.md)	 - List configured profiles
+* [gr4vy config path](gr4vy_config_path.md)	 - Print the resolved config path and secret backend
+* [gr4vy config remove](gr4vy_config_remove.md)	 - Remove a profile and its secrets
+* [gr4vy config show](gr4vy_config_show.md)	 - Show a profile (secrets redacted)
+* [gr4vy config use](gr4vy_config_use.md)	 - Set the active profile
+

--- a/docs/gr4vy_config_add.md
+++ b/docs/gr4vy_config_add.md
@@ -1,0 +1,45 @@
+## gr4vy config add
+
+Add or update a profile
+
+```
+gr4vy config add <name> [flags]
+```
+
+### Options
+
+```
+      --auth-host string             override the auth host for login
+      --auth-method string           key or login (default key)
+      --default-scope strings        default token scope (repeatable)
+      --email string                 login email (for auth-method=login)
+      --environment string           sandbox or production
+  -h, --help                         help for add
+      --id string                    Gr4vy instance id
+      --key-env string               name of an env var holding the PEM private key
+      --key-file string              path to a PEM private key to import into the secret store
+      --key-path string              reference a PEM file in place (not copied into the store)
+      --key-stdin                    read the PEM private key from stdin
+      --merchant-account-id string   default merchant account id
+      --no-input                     never prompt; fail if a required field is missing
+      --set-active                   make this the active profile
+      --token-ttl string             default token lifetime, e.g. 1h
+```
+
+### Options inherited from parent commands
+
+```
+      --compact            compact single-line JSON output
+      --config string      path to the config file (env: GR4VY_CONFIG)
+      --debug              print debug information to stderr
+  -o, --output string      output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string     configuration profile to use (env: GR4VY_PROFILE)
+      --server string      server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration   per-request timeout, e.g. 30s
+      --token string       pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy config](gr4vy_config.md)	 - Manage configuration profiles
+

--- a/docs/gr4vy_config_import.md
+++ b/docs/gr4vy_config_import.md
@@ -1,0 +1,37 @@
+## gr4vy config import
+
+Import the legacy ~/.gr4vyrc.json into a profile
+
+```
+gr4vy config import [flags]
+```
+
+### Options
+
+```
+      --delete-legacy   delete the legacy file after import
+      --from string     path to the legacy config (default ~/.gr4vyrc.json)
+  -h, --help            help for import
+      --name string     profile name to create (default "default")
+      --set-active      make the imported profile active
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy config](gr4vy_config.md)	 - Manage configuration profiles
+

--- a/docs/gr4vy_config_key.md
+++ b/docs/gr4vy_config_key.md
@@ -1,0 +1,38 @@
+## gr4vy config key
+
+Print the active profile's private key (PEM)
+
+### Synopsis
+
+Output the private key the selected profile would use, resolved from the secret store, a key file, or the environment. Select a profile with --profile. Handle the output with care — it is your secret signing key.
+
+```
+gr4vy config key [flags]
+```
+
+### Options
+
+```
+      --base64   output the key base64-encoded (single line)
+  -h, --help     help for key
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy config](gr4vy_config.md)	 - Manage configuration profiles
+

--- a/docs/gr4vy_config_list.md
+++ b/docs/gr4vy_config_list.md
@@ -1,0 +1,33 @@
+## gr4vy config list
+
+List configured profiles
+
+```
+gr4vy config list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy config](gr4vy_config.md)	 - Manage configuration profiles
+

--- a/docs/gr4vy_config_path.md
+++ b/docs/gr4vy_config_path.md
@@ -1,0 +1,33 @@
+## gr4vy config path
+
+Print the resolved config path and secret backend
+
+```
+gr4vy config path [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for path
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy config](gr4vy_config.md)	 - Manage configuration profiles
+

--- a/docs/gr4vy_config_remove.md
+++ b/docs/gr4vy_config_remove.md
@@ -1,0 +1,35 @@
+## gr4vy config remove
+
+Remove a profile and its secrets
+
+```
+gr4vy config remove <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for remove
+      --keep-secrets   do not delete stored secrets
+      --yes            do not prompt for confirmation
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy config](gr4vy_config.md)	 - Manage configuration profiles
+

--- a/docs/gr4vy_config_show.md
+++ b/docs/gr4vy_config_show.md
@@ -1,0 +1,33 @@
+## gr4vy config show
+
+Show a profile (secrets redacted)
+
+```
+gr4vy config show [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy config](gr4vy_config.md)	 - Manage configuration profiles
+

--- a/docs/gr4vy_config_use.md
+++ b/docs/gr4vy_config_use.md
@@ -1,0 +1,33 @@
+## gr4vy config use
+
+Set the active profile
+
+```
+gr4vy config use <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for use
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy config](gr4vy_config.md)	 - Manage configuration profiles
+

--- a/docs/gr4vy_digital-wallets.md
+++ b/docs/gr4vy_digital-wallets.md
@@ -1,0 +1,36 @@
+## gr4vy digital-wallets
+
+Manage digital-wallets
+
+### Options
+
+```
+  -h, --help   help for digital-wallets
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy digital-wallets create](gr4vy_digital-wallets_create.md)	 - Register digital wallet
+* [gr4vy digital-wallets delete](gr4vy_digital-wallets_delete.md)	 - Delete digital wallet
+* [gr4vy digital-wallets domains](gr4vy_digital-wallets_domains.md)	 - Manage digital-wallets domains
+* [gr4vy digital-wallets get](gr4vy_digital-wallets_get.md)	 - Get digital wallet
+* [gr4vy digital-wallets list](gr4vy_digital-wallets_list.md)	 - List digital wallets
+* [gr4vy digital-wallets sessions](gr4vy_digital-wallets_sessions.md)	 - Manage digital-wallets sessions
+* [gr4vy digital-wallets update](gr4vy_digital-wallets_update.md)	 - Update digital wallet
+

--- a/docs/gr4vy_digital-wallets_create.md
+++ b/docs/gr4vy_digital-wallets_create.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets create
+
+Register digital wallet
+
+### Synopsis
+
+Register digital wallet
+
+Register a digital wallet like Apple Pay, Google Pay, or Click to Pay.
+
+```
+gr4vy digital-wallets create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (DigitalWalletCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets](gr4vy_digital-wallets.md)	 - Manage digital-wallets
+

--- a/docs/gr4vy_digital-wallets_delete.md
+++ b/docs/gr4vy_digital-wallets_delete.md
@@ -1,0 +1,39 @@
+## gr4vy digital-wallets delete
+
+Delete digital wallet
+
+### Synopsis
+
+Delete digital wallet
+
+Delete a configured digital wallet.
+
+```
+gr4vy digital-wallets delete <digital-wallet-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets](gr4vy_digital-wallets.md)	 - Manage digital-wallets
+

--- a/docs/gr4vy_digital-wallets_domains.md
+++ b/docs/gr4vy_digital-wallets_domains.md
@@ -1,0 +1,31 @@
+## gr4vy digital-wallets domains
+
+Manage digital-wallets domains
+
+### Options
+
+```
+  -h, --help   help for domains
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets](gr4vy_digital-wallets.md)	 - Manage digital-wallets
+* [gr4vy digital-wallets domains create](gr4vy_digital-wallets_domains_create.md)	 - Register a digital wallet domain
+* [gr4vy digital-wallets domains delete](gr4vy_digital-wallets_domains_delete.md)	 - Remove a digital wallet domain
+

--- a/docs/gr4vy_digital-wallets_domains_create.md
+++ b/docs/gr4vy_digital-wallets_domains_create.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets domains create
+
+Register a digital wallet domain
+
+### Synopsis
+
+Register a digital wallet domain
+
+Register a digital wallet domain (Apple Pay only).
+
+```
+gr4vy digital-wallets domains create <digital-wallet-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (DigitalWalletDomain)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets domains](gr4vy_digital-wallets_domains.md)	 - Manage digital-wallets domains
+

--- a/docs/gr4vy_digital-wallets_domains_delete.md
+++ b/docs/gr4vy_digital-wallets_domains_delete.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets domains delete
+
+Remove a digital wallet domain
+
+### Synopsis
+
+Remove a digital wallet domain
+
+Remove a digital wallet domain (Apple Pay only).
+
+```
+gr4vy digital-wallets domains delete <digital-wallet-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (DigitalWalletDomain)
+  -h, --help          help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets domains](gr4vy_digital-wallets_domains.md)	 - Manage digital-wallets domains
+

--- a/docs/gr4vy_digital-wallets_get.md
+++ b/docs/gr4vy_digital-wallets_get.md
@@ -1,0 +1,39 @@
+## gr4vy digital-wallets get
+
+Get digital wallet
+
+### Synopsis
+
+Get digital wallet
+
+Fetch the details a digital wallet.
+
+```
+gr4vy digital-wallets get <digital-wallet-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets](gr4vy_digital-wallets.md)	 - Manage digital-wallets
+

--- a/docs/gr4vy_digital-wallets_list.md
+++ b/docs/gr4vy_digital-wallets_list.md
@@ -1,0 +1,39 @@
+## gr4vy digital-wallets list
+
+List digital wallets
+
+### Synopsis
+
+List digital wallets
+
+List configured digital wallets.
+
+```
+gr4vy digital-wallets list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets](gr4vy_digital-wallets.md)	 - Manage digital-wallets
+

--- a/docs/gr4vy_digital-wallets_sessions.md
+++ b/docs/gr4vy_digital-wallets_sessions.md
@@ -1,0 +1,36 @@
+## gr4vy digital-wallets sessions
+
+Manage digital-wallets sessions
+
+### Options
+
+```
+  -h, --help   help for sessions
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets](gr4vy_digital-wallets.md)	 - Manage digital-wallets
+* [gr4vy digital-wallets sessions apple-pay](gr4vy_digital-wallets_sessions_apple-pay.md)	 - Create a Apple Pay session
+* [gr4vy digital-wallets sessions click-to-pay](gr4vy_digital-wallets_sessions_click-to-pay.md)	 - Create a Click to Pay session
+* [gr4vy digital-wallets sessions google-pay](gr4vy_digital-wallets_sessions_google-pay.md)	 - Create a Google Pay session
+* [gr4vy digital-wallets sessions paze](gr4vy_digital-wallets_sessions_paze.md)	 - Create a Paze session
+* [gr4vy digital-wallets sessions paze-mobile-session-complete](gr4vy_digital-wallets_sessions_paze-mobile-session-complete.md)	 - Complete a Paze session
+* [gr4vy digital-wallets sessions paze-mobile-session-create](gr4vy_digital-wallets_sessions_paze-mobile-session-create.md)	 - Create a Paze mobile session
+* [gr4vy digital-wallets sessions paze-mobile-session-review](gr4vy_digital-wallets_sessions_paze-mobile-session-review.md)	 - Review a Paze session
+

--- a/docs/gr4vy_digital-wallets_sessions_apple-pay.md
+++ b/docs/gr4vy_digital-wallets_sessions_apple-pay.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets sessions apple-pay
+
+Create a Apple Pay session
+
+### Synopsis
+
+Create a Apple Pay session
+
+Create a session for use with Apple Pay.
+
+```
+gr4vy digital-wallets sessions apple-pay [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (ApplePaySessionRequest)
+  -h, --help          help for apple-pay
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets sessions](gr4vy_digital-wallets_sessions.md)	 - Manage digital-wallets sessions
+

--- a/docs/gr4vy_digital-wallets_sessions_click-to-pay.md
+++ b/docs/gr4vy_digital-wallets_sessions_click-to-pay.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets sessions click-to-pay
+
+Create a Click to Pay session
+
+### Synopsis
+
+Create a Click to Pay session
+
+Create a session for use with Click to Pay.
+
+```
+gr4vy digital-wallets sessions click-to-pay [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (ClickToPaySessionRequest)
+  -h, --help          help for click-to-pay
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets sessions](gr4vy_digital-wallets_sessions.md)	 - Manage digital-wallets sessions
+

--- a/docs/gr4vy_digital-wallets_sessions_google-pay.md
+++ b/docs/gr4vy_digital-wallets_sessions_google-pay.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets sessions google-pay
+
+Create a Google Pay session
+
+### Synopsis
+
+Create a Google Pay session
+
+Create a session for use with Google Pay.
+
+```
+gr4vy digital-wallets sessions google-pay [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (GooglePaySessionRequest)
+  -h, --help          help for google-pay
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets sessions](gr4vy_digital-wallets_sessions.md)	 - Manage digital-wallets sessions
+

--- a/docs/gr4vy_digital-wallets_sessions_paze-mobile-session-complete.md
+++ b/docs/gr4vy_digital-wallets_sessions_paze-mobile-session-complete.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets sessions paze-mobile-session-complete
+
+Complete a Paze session
+
+### Synopsis
+
+Complete a Paze session
+
+Complete a Paze checkout session and retrieve the secure payload required to settle the payment.
+
+```
+gr4vy digital-wallets sessions paze-mobile-session-complete [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PazeSessionCompleteRequest)
+  -h, --help          help for paze-mobile-session-complete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets sessions](gr4vy_digital-wallets_sessions.md)	 - Manage digital-wallets sessions
+

--- a/docs/gr4vy_digital-wallets_sessions_paze-mobile-session-create.md
+++ b/docs/gr4vy_digital-wallets_sessions_paze-mobile-session-create.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets sessions paze-mobile-session-create
+
+Create a Paze mobile session
+
+### Synopsis
+
+Create a Paze mobile session
+
+Create a mobile session for use with Paze.
+
+```
+gr4vy digital-wallets sessions paze-mobile-session-create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PazeMobileSessionCreateRequest)
+  -h, --help          help for paze-mobile-session-create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets sessions](gr4vy_digital-wallets_sessions.md)	 - Manage digital-wallets sessions
+

--- a/docs/gr4vy_digital-wallets_sessions_paze-mobile-session-review.md
+++ b/docs/gr4vy_digital-wallets_sessions_paze-mobile-session-review.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets sessions paze-mobile-session-review
+
+Review a Paze session
+
+### Synopsis
+
+Review a Paze session
+
+Review a Paze checkout session and retrieve the selected card, consumer, and shipping address details.
+
+```
+gr4vy digital-wallets sessions paze-mobile-session-review [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PazeSessionReviewRequest)
+  -h, --help          help for paze-mobile-session-review
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets sessions](gr4vy_digital-wallets_sessions.md)	 - Manage digital-wallets sessions
+

--- a/docs/gr4vy_digital-wallets_sessions_paze.md
+++ b/docs/gr4vy_digital-wallets_sessions_paze.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets sessions paze
+
+Create a Paze session
+
+### Synopsis
+
+Create a Paze session
+
+Create a session for use with Paze.
+
+```
+gr4vy digital-wallets sessions paze [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PazeSessionRequest)
+  -h, --help          help for paze
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets sessions](gr4vy_digital-wallets_sessions.md)	 - Manage digital-wallets sessions
+

--- a/docs/gr4vy_digital-wallets_update.md
+++ b/docs/gr4vy_digital-wallets_update.md
@@ -1,0 +1,40 @@
+## gr4vy digital-wallets update
+
+Update digital wallet
+
+### Synopsis
+
+Update digital wallet
+
+Update a digital wallet.
+
+```
+gr4vy digital-wallets update <digital-wallet-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (DigitalWalletUpdate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy digital-wallets](gr4vy_digital-wallets.md)	 - Manage digital-wallets
+

--- a/docs/gr4vy_embed.md
+++ b/docs/gr4vy_embed.md
@@ -1,0 +1,40 @@
+## gr4vy embed
+
+Generate an Embed token for the checkout form
+
+### Synopsis
+
+Generate a JWT for Gr4vy Embed, pinning the given amount, currency, and any extra key=value parameters. With --checkout-session, a checkout session is created and its id is baked into the token.
+
+```
+gr4vy embed <amount> <currency> [key=value ...] [flags]
+```
+
+### Options
+
+```
+      --checkout-session    create a checkout session and pin its id into the token
+  -h, --help                help for embed
+      --mid string          merchant account id for the checkout session (with --checkout-session)
+      --param stringArray   extra embed parameter as key=value (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+

--- a/docs/gr4vy_gift-cards.md
+++ b/docs/gr4vy_gift-cards.md
@@ -1,0 +1,34 @@
+## gr4vy gift-cards
+
+Manage gift-cards
+
+### Options
+
+```
+  -h, --help   help for gift-cards
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy gift-cards balances](gr4vy_gift-cards_balances.md)	 - Manage gift-cards balances
+* [gr4vy gift-cards create](gr4vy_gift-cards_create.md)	 - Create gift card
+* [gr4vy gift-cards delete](gr4vy_gift-cards_delete.md)	 - Delete a gift card
+* [gr4vy gift-cards get](gr4vy_gift-cards_get.md)	 - Get gift card
+* [gr4vy gift-cards list](gr4vy_gift-cards_list.md)	 - List gift cards
+

--- a/docs/gr4vy_gift-cards_balances.md
+++ b/docs/gr4vy_gift-cards_balances.md
@@ -1,0 +1,30 @@
+## gr4vy gift-cards balances
+
+Manage gift-cards balances
+
+### Options
+
+```
+  -h, --help   help for balances
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy gift-cards](gr4vy_gift-cards.md)	 - Manage gift-cards
+* [gr4vy gift-cards balances list](gr4vy_gift-cards_balances_list.md)	 - List gift card balances
+

--- a/docs/gr4vy_gift-cards_balances_list.md
+++ b/docs/gr4vy_gift-cards_balances_list.md
@@ -1,0 +1,40 @@
+## gr4vy gift-cards balances list
+
+List gift card balances
+
+### Synopsis
+
+List gift card balances
+
+Fetch the balances for one or more gift cards.
+
+```
+gr4vy gift-cards balances list [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (GiftCardBalanceRequest)
+  -h, --help          help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy gift-cards balances](gr4vy_gift-cards_balances.md)	 - Manage gift-cards balances
+

--- a/docs/gr4vy_gift-cards_create.md
+++ b/docs/gr4vy_gift-cards_create.md
@@ -1,0 +1,40 @@
+## gr4vy gift-cards create
+
+Create gift card
+
+### Synopsis
+
+Create gift card
+
+Store a new gift card in the vault.
+
+```
+gr4vy gift-cards create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (GiftCardCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy gift-cards](gr4vy_gift-cards.md)	 - Manage gift-cards
+

--- a/docs/gr4vy_gift-cards_delete.md
+++ b/docs/gr4vy_gift-cards_delete.md
@@ -1,0 +1,39 @@
+## gr4vy gift-cards delete
+
+Delete a gift card
+
+### Synopsis
+
+Delete a gift card
+
+Removes a gift card from our system.
+
+```
+gr4vy gift-cards delete <gift-card-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy gift-cards](gr4vy_gift-cards.md)	 - Manage gift-cards
+

--- a/docs/gr4vy_gift-cards_get.md
+++ b/docs/gr4vy_gift-cards_get.md
@@ -1,0 +1,39 @@
+## gr4vy gift-cards get
+
+Get gift card
+
+### Synopsis
+
+Get gift card
+
+Fetch details about a gift card.
+
+```
+gr4vy gift-cards get <gift-card-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy gift-cards](gr4vy_gift-cards.md)	 - Manage gift-cards
+

--- a/docs/gr4vy_gift-cards_list.md
+++ b/docs/gr4vy_gift-cards_list.md
@@ -1,0 +1,43 @@
+## gr4vy gift-cards list
+
+List gift cards
+
+### Synopsis
+
+List gift cards
+
+Browser all gift cards.
+
+```
+gr4vy gift-cards list [flags]
+```
+
+### Options
+
+```
+      --buyer-external-identifier string   buyer-external-identifier parameter
+      --buyer-id string                    buyer-id parameter
+      --cursor string                      pagination cursor
+  -h, --help                               help for list
+      --limit int                          maximum number of items to return
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy gift-cards](gr4vy_gift-cards.md)	 - Manage gift-cards
+

--- a/docs/gr4vy_init.md
+++ b/docs/gr4vy_init.md
@@ -1,0 +1,49 @@
+## gr4vy init
+
+Create your first profile interactively
+
+### Synopsis
+
+Bootstrap a configuration profile. Prompts interactively on a terminal; use flags (and --no-input) for scripted setup.
+
+```
+gr4vy init [name] [flags]
+```
+
+### Options
+
+```
+      --auth-host string             override the auth host for login
+      --auth-method string           key or login (default key)
+      --default-scope strings        default token scope (repeatable)
+      --email string                 login email (for auth-method=login)
+      --environment string           sandbox or production
+  -h, --help                         help for init
+      --id string                    Gr4vy instance id
+      --key-env string               name of an env var holding the PEM private key
+      --key-file string              path to a PEM private key to import into the secret store
+      --key-path string              reference a PEM file in place (not copied into the store)
+      --key-stdin                    read the PEM private key from stdin
+      --merchant-account-id string   default merchant account id
+      --no-input                     never prompt; fail if a required field is missing
+      --set-active                   make this the active profile
+      --token-ttl string             default token lifetime, e.g. 1h
+```
+
+### Options inherited from parent commands
+
+```
+      --compact            compact single-line JSON output
+      --config string      path to the config file (env: GR4VY_CONFIG)
+      --debug              print debug information to stderr
+  -o, --output string      output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string     configuration profile to use (env: GR4VY_PROFILE)
+      --server string      server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration   per-request timeout, e.g. 30s
+      --token string       pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+

--- a/docs/gr4vy_login.md
+++ b/docs/gr4vy_login.md
@@ -1,0 +1,39 @@
+## gr4vy login
+
+Log in with email and password
+
+### Synopsis
+
+Authenticate against the Gr4vy session endpoint and store the resulting tokens for the active profile. The CLI refreshes the access token automatically.
+
+```
+gr4vy login [flags]
+```
+
+### Options
+
+```
+      --email string     login email
+  -h, --help             help for login
+      --password-stdin   read the password from stdin
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+

--- a/docs/gr4vy_logout.md
+++ b/docs/gr4vy_logout.md
@@ -1,0 +1,33 @@
+## gr4vy logout
+
+Log out and clear stored session tokens
+
+```
+gr4vy logout [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for logout
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+

--- a/docs/gr4vy_merchant-accounts.md
+++ b/docs/gr4vy_merchant-accounts.md
@@ -1,0 +1,34 @@
+## gr4vy merchant-accounts
+
+Manage merchant-accounts
+
+### Options
+
+```
+  -h, --help   help for merchant-accounts
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy merchant-accounts create](gr4vy_merchant-accounts_create.md)	 - Create a merchant account
+* [gr4vy merchant-accounts get](gr4vy_merchant-accounts_get.md)	 - Get a merchant account
+* [gr4vy merchant-accounts list](gr4vy_merchant-accounts_list.md)	 - List all merchant accounts
+* [gr4vy merchant-accounts three-ds-configuration](gr4vy_merchant-accounts_three-ds-configuration.md)	 - Manage merchant-accounts three-ds-configuration
+* [gr4vy merchant-accounts update](gr4vy_merchant-accounts_update.md)	 - Update a merchant account
+

--- a/docs/gr4vy_merchant-accounts_create.md
+++ b/docs/gr4vy_merchant-accounts_create.md
@@ -1,0 +1,40 @@
+## gr4vy merchant-accounts create
+
+Create a merchant account
+
+### Synopsis
+
+Create a merchant account
+
+Create a new merchant account in an instance.
+
+```
+gr4vy merchant-accounts create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (MerchantAccountCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy merchant-accounts](gr4vy_merchant-accounts.md)	 - Manage merchant-accounts
+

--- a/docs/gr4vy_merchant-accounts_get.md
+++ b/docs/gr4vy_merchant-accounts_get.md
@@ -1,0 +1,39 @@
+## gr4vy merchant-accounts get
+
+Get a merchant account
+
+### Synopsis
+
+Get a merchant account
+
+Get info about a merchant account in an instance.
+
+```
+gr4vy merchant-accounts get <merchant-account-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy merchant-accounts](gr4vy_merchant-accounts.md)	 - Manage merchant-accounts
+

--- a/docs/gr4vy_merchant-accounts_list.md
+++ b/docs/gr4vy_merchant-accounts_list.md
@@ -1,0 +1,42 @@
+## gr4vy merchant-accounts list
+
+List all merchant accounts
+
+### Synopsis
+
+List all merchant accounts
+
+List all merchant accounts in an instance.
+
+```
+gr4vy merchant-accounts list [flags]
+```
+
+### Options
+
+```
+      --cursor string   pagination cursor
+  -h, --help            help for list
+      --limit int       maximum number of items to return
+      --search string   free-text search filter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy merchant-accounts](gr4vy_merchant-accounts.md)	 - Manage merchant-accounts
+

--- a/docs/gr4vy_merchant-accounts_three-ds-configuration.md
+++ b/docs/gr4vy_merchant-accounts_three-ds-configuration.md
@@ -1,0 +1,33 @@
+## gr4vy merchant-accounts three-ds-configuration
+
+Manage merchant-accounts three-ds-configuration
+
+### Options
+
+```
+  -h, --help   help for three-ds-configuration
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy merchant-accounts](gr4vy_merchant-accounts.md)	 - Manage merchant-accounts
+* [gr4vy merchant-accounts three-ds-configuration create](gr4vy_merchant-accounts_three-ds-configuration_create.md)	 - Create 3DS configuration for merchant
+* [gr4vy merchant-accounts three-ds-configuration delete](gr4vy_merchant-accounts_three-ds-configuration_delete.md)	 - Delete 3DS configuration for a merchant
+* [gr4vy merchant-accounts three-ds-configuration list](gr4vy_merchant-accounts_three-ds-configuration_list.md)	 - List 3DS configurations for merchant
+* [gr4vy merchant-accounts three-ds-configuration update](gr4vy_merchant-accounts_three-ds-configuration_update.md)	 - Edit 3DS configuration
+

--- a/docs/gr4vy_merchant-accounts_three-ds-configuration_create.md
+++ b/docs/gr4vy_merchant-accounts_three-ds-configuration_create.md
@@ -1,0 +1,40 @@
+## gr4vy merchant-accounts three-ds-configuration create
+
+Create 3DS configuration for merchant
+
+### Synopsis
+
+Create 3DS configuration for merchant
+
+Create a new 3DS configuration for a merchant account.
+
+```
+gr4vy merchant-accounts three-ds-configuration create <merchant-account-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (MerchantAccountThreeDSConfigurationCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy merchant-accounts three-ds-configuration](gr4vy_merchant-accounts_three-ds-configuration.md)	 - Manage merchant-accounts three-ds-configuration
+

--- a/docs/gr4vy_merchant-accounts_three-ds-configuration_delete.md
+++ b/docs/gr4vy_merchant-accounts_three-ds-configuration_delete.md
@@ -1,0 +1,39 @@
+## gr4vy merchant-accounts three-ds-configuration delete
+
+Delete 3DS configuration for a merchant
+
+### Synopsis
+
+Delete 3DS configuration for a merchant
+
+Delete a 3DS configuration for a merchant account.
+
+```
+gr4vy merchant-accounts three-ds-configuration delete <merchant-account-id> <three-ds-configuration-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy merchant-accounts three-ds-configuration](gr4vy_merchant-accounts_three-ds-configuration.md)	 - Manage merchant-accounts three-ds-configuration
+

--- a/docs/gr4vy_merchant-accounts_three-ds-configuration_list.md
+++ b/docs/gr4vy_merchant-accounts_three-ds-configuration_list.md
@@ -1,0 +1,40 @@
+## gr4vy merchant-accounts three-ds-configuration list
+
+List 3DS configurations for merchant
+
+### Synopsis
+
+List 3DS configurations for merchant
+
+List all 3DS configurations for a merchant account.
+
+```
+gr4vy merchant-accounts three-ds-configuration list <merchant-account-id> [flags]
+```
+
+### Options
+
+```
+      --currency string   currency parameter
+  -h, --help              help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy merchant-accounts three-ds-configuration](gr4vy_merchant-accounts_three-ds-configuration.md)	 - Manage merchant-accounts three-ds-configuration
+

--- a/docs/gr4vy_merchant-accounts_three-ds-configuration_update.md
+++ b/docs/gr4vy_merchant-accounts_three-ds-configuration_update.md
@@ -1,0 +1,40 @@
+## gr4vy merchant-accounts three-ds-configuration update
+
+Edit 3DS configuration
+
+### Synopsis
+
+Edit 3DS configuration
+
+Update the 3DS configuration for a merchant account.
+
+```
+gr4vy merchant-accounts three-ds-configuration update <merchant-account-id> <three-ds-configuration-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (MerchantAccountThreeDSConfigurationUpdate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy merchant-accounts three-ds-configuration](gr4vy_merchant-accounts_three-ds-configuration.md)	 - Manage merchant-accounts three-ds-configuration
+

--- a/docs/gr4vy_merchant-accounts_update.md
+++ b/docs/gr4vy_merchant-accounts_update.md
@@ -1,0 +1,40 @@
+## gr4vy merchant-accounts update
+
+Update a merchant account
+
+### Synopsis
+
+Update a merchant account
+
+Update info for a merchant account in an instance.
+
+```
+gr4vy merchant-accounts update <merchant-account-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (MerchantAccountUpdate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy merchant-accounts](gr4vy_merchant-accounts.md)	 - Manage merchant-accounts
+

--- a/docs/gr4vy_payment-links.md
+++ b/docs/gr4vy_payment-links.md
@@ -1,0 +1,33 @@
+## gr4vy payment-links
+
+Manage payment-links
+
+### Options
+
+```
+  -h, --help   help for payment-links
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy payment-links create](gr4vy_payment-links_create.md)	 - Add a payment link
+* [gr4vy payment-links expire](gr4vy_payment-links_expire.md)	 - Expire a payment link
+* [gr4vy payment-links get](gr4vy_payment-links_get.md)	 - Get payment link
+* [gr4vy payment-links list](gr4vy_payment-links_list.md)	 - List all payment links
+

--- a/docs/gr4vy_payment-links_create.md
+++ b/docs/gr4vy_payment-links_create.md
@@ -1,0 +1,40 @@
+## gr4vy payment-links create
+
+Add a payment link
+
+### Synopsis
+
+Add a payment link
+
+Create a new payment link.
+
+```
+gr4vy payment-links create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PaymentLinkCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-links](gr4vy_payment-links.md)	 - Manage payment-links
+

--- a/docs/gr4vy_payment-links_expire.md
+++ b/docs/gr4vy_payment-links_expire.md
@@ -1,0 +1,39 @@
+## gr4vy payment-links expire
+
+Expire a payment link
+
+### Synopsis
+
+Expire a payment link
+
+Expire an existing payment link.
+
+```
+gr4vy payment-links expire <payment-link-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for expire
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-links](gr4vy_payment-links.md)	 - Manage payment-links
+

--- a/docs/gr4vy_payment-links_get.md
+++ b/docs/gr4vy_payment-links_get.md
@@ -1,0 +1,39 @@
+## gr4vy payment-links get
+
+Get payment link
+
+### Synopsis
+
+Get payment link
+
+Fetch the details for a payment link.
+
+```
+gr4vy payment-links get <payment-link-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-links](gr4vy_payment-links.md)	 - Manage payment-links
+

--- a/docs/gr4vy_payment-links_list.md
+++ b/docs/gr4vy_payment-links_list.md
@@ -1,0 +1,42 @@
+## gr4vy payment-links list
+
+List all payment links
+
+### Synopsis
+
+List all payment links
+
+List all created payment links.
+
+```
+gr4vy payment-links list [flags]
+```
+
+### Options
+
+```
+      --buyer-search strings   buyer-search parameter
+      --cursor string          pagination cursor
+  -h, --help                   help for list
+      --limit int              maximum number of items to return
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-links](gr4vy_payment-links.md)	 - Manage payment-links
+

--- a/docs/gr4vy_payment-methods.md
+++ b/docs/gr4vy_payment-methods.md
@@ -1,0 +1,36 @@
+## gr4vy payment-methods
+
+Manage payment-methods
+
+### Options
+
+```
+  -h, --help   help for payment-methods
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy payment-methods create](gr4vy_payment-methods_create.md)	 - Create payment method
+* [gr4vy payment-methods delete](gr4vy_payment-methods_delete.md)	 - Delete payment method
+* [gr4vy payment-methods get](gr4vy_payment-methods_get.md)	 - Get payment method
+* [gr4vy payment-methods list](gr4vy_payment-methods_list.md)	 - List all payment methods
+* [gr4vy payment-methods network-tokens](gr4vy_payment-methods_network-tokens.md)	 - Manage payment-methods network-tokens
+* [gr4vy payment-methods payment-service-tokens](gr4vy_payment-methods_payment-service-tokens.md)	 - Manage payment-methods payment-service-tokens
+* [gr4vy payment-methods update](gr4vy_payment-methods_update.md)	 - Update payment method
+

--- a/docs/gr4vy_payment-methods_create.md
+++ b/docs/gr4vy_payment-methods_create.md
@@ -1,0 +1,40 @@
+## gr4vy payment-methods create
+
+Create payment method
+
+### Synopsis
+
+Create payment method
+
+Store a new payment method.
+
+```
+gr4vy payment-methods create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (Body)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods](gr4vy_payment-methods.md)	 - Manage payment-methods
+

--- a/docs/gr4vy_payment-methods_delete.md
+++ b/docs/gr4vy_payment-methods_delete.md
@@ -1,0 +1,39 @@
+## gr4vy payment-methods delete
+
+Delete payment method
+
+### Synopsis
+
+Delete payment method
+
+Delete a payment method.
+
+```
+gr4vy payment-methods delete <payment-method-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods](gr4vy_payment-methods.md)	 - Manage payment-methods
+

--- a/docs/gr4vy_payment-methods_get.md
+++ b/docs/gr4vy_payment-methods_get.md
@@ -1,0 +1,39 @@
+## gr4vy payment-methods get
+
+Get payment method
+
+### Synopsis
+
+Get payment method
+
+Retrieve a payment method.
+
+```
+gr4vy payment-methods get <payment-method-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods](gr4vy_payment-methods.md)	 - Manage payment-methods
+

--- a/docs/gr4vy_payment-methods_list.md
+++ b/docs/gr4vy_payment-methods_list.md
@@ -1,0 +1,44 @@
+## gr4vy payment-methods list
+
+List all payment methods
+
+### Synopsis
+
+List all payment methods
+
+List all stored payment method.
+
+```
+gr4vy payment-methods list [flags]
+```
+
+### Options
+
+```
+      --buyer-external-identifier string   buyer-external-identifier parameter
+      --buyer-id string                    buyer-id parameter
+      --cursor string                      pagination cursor
+      --external-identifier string         external-identifier parameter
+  -h, --help                               help for list
+      --limit int                          maximum number of items to return
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods](gr4vy_payment-methods.md)	 - Manage payment-methods
+

--- a/docs/gr4vy_payment-methods_network-tokens.md
+++ b/docs/gr4vy_payment-methods_network-tokens.md
@@ -1,0 +1,35 @@
+## gr4vy payment-methods network-tokens
+
+Manage payment-methods network-tokens
+
+### Options
+
+```
+  -h, --help   help for network-tokens
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods](gr4vy_payment-methods.md)	 - Manage payment-methods
+* [gr4vy payment-methods network-tokens create](gr4vy_payment-methods_network-tokens_create.md)	 - Provision network token
+* [gr4vy payment-methods network-tokens cryptogram](gr4vy_payment-methods_network-tokens_cryptogram.md)	 - Manage payment-methods network-tokens cryptogram
+* [gr4vy payment-methods network-tokens delete](gr4vy_payment-methods_network-tokens_delete.md)	 - Delete network token
+* [gr4vy payment-methods network-tokens list](gr4vy_payment-methods_network-tokens_list.md)	 - List network tokens
+* [gr4vy payment-methods network-tokens resume](gr4vy_payment-methods_network-tokens_resume.md)	 - Resume network token
+* [gr4vy payment-methods network-tokens suspend](gr4vy_payment-methods_network-tokens_suspend.md)	 - Suspend network token
+

--- a/docs/gr4vy_payment-methods_network-tokens_create.md
+++ b/docs/gr4vy_payment-methods_network-tokens_create.md
@@ -1,0 +1,40 @@
+## gr4vy payment-methods network-tokens create
+
+Provision network token
+
+### Synopsis
+
+Provision network token
+
+Provision a network token for a payment method.
+
+```
+gr4vy payment-methods network-tokens create <payment-method-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (NetworkTokenCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods network-tokens](gr4vy_payment-methods_network-tokens.md)	 - Manage payment-methods network-tokens
+

--- a/docs/gr4vy_payment-methods_network-tokens_cryptogram.md
+++ b/docs/gr4vy_payment-methods_network-tokens_cryptogram.md
@@ -1,0 +1,30 @@
+## gr4vy payment-methods network-tokens cryptogram
+
+Manage payment-methods network-tokens cryptogram
+
+### Options
+
+```
+  -h, --help   help for cryptogram
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods network-tokens](gr4vy_payment-methods_network-tokens.md)	 - Manage payment-methods network-tokens
+* [gr4vy payment-methods network-tokens cryptogram create](gr4vy_payment-methods_network-tokens_cryptogram_create.md)	 - Provision network token cryptogram
+

--- a/docs/gr4vy_payment-methods_network-tokens_cryptogram_create.md
+++ b/docs/gr4vy_payment-methods_network-tokens_cryptogram_create.md
@@ -1,0 +1,40 @@
+## gr4vy payment-methods network-tokens cryptogram create
+
+Provision network token cryptogram
+
+### Synopsis
+
+Provision network token cryptogram
+
+Provision a cryptogram for a network token.
+
+```
+gr4vy payment-methods network-tokens cryptogram create <payment-method-id> <network-token-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (CryptogramCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods network-tokens cryptogram](gr4vy_payment-methods_network-tokens_cryptogram.md)	 - Manage payment-methods network-tokens cryptogram
+

--- a/docs/gr4vy_payment-methods_network-tokens_delete.md
+++ b/docs/gr4vy_payment-methods_network-tokens_delete.md
@@ -1,0 +1,39 @@
+## gr4vy payment-methods network-tokens delete
+
+Delete network token
+
+### Synopsis
+
+Delete network token
+
+Delete a network token for a payment method.
+
+```
+gr4vy payment-methods network-tokens delete <payment-method-id> <network-token-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods network-tokens](gr4vy_payment-methods_network-tokens.md)	 - Manage payment-methods network-tokens
+

--- a/docs/gr4vy_payment-methods_network-tokens_list.md
+++ b/docs/gr4vy_payment-methods_network-tokens_list.md
@@ -1,0 +1,39 @@
+## gr4vy payment-methods network-tokens list
+
+List network tokens
+
+### Synopsis
+
+List network tokens
+
+List all network tokens stored for a payment method.
+
+```
+gr4vy payment-methods network-tokens list <payment-method-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods network-tokens](gr4vy_payment-methods_network-tokens.md)	 - Manage payment-methods network-tokens
+

--- a/docs/gr4vy_payment-methods_network-tokens_resume.md
+++ b/docs/gr4vy_payment-methods_network-tokens_resume.md
@@ -1,0 +1,39 @@
+## gr4vy payment-methods network-tokens resume
+
+Resume network token
+
+### Synopsis
+
+Resume network token
+
+Resume a suspended network token for a payment method.
+
+```
+gr4vy payment-methods network-tokens resume <payment-method-id> <network-token-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for resume
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods network-tokens](gr4vy_payment-methods_network-tokens.md)	 - Manage payment-methods network-tokens
+

--- a/docs/gr4vy_payment-methods_network-tokens_suspend.md
+++ b/docs/gr4vy_payment-methods_network-tokens_suspend.md
@@ -1,0 +1,39 @@
+## gr4vy payment-methods network-tokens suspend
+
+Suspend network token
+
+### Synopsis
+
+Suspend network token
+
+Suspend a network token for a payment method.
+
+```
+gr4vy payment-methods network-tokens suspend <payment-method-id> <network-token-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for suspend
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods network-tokens](gr4vy_payment-methods_network-tokens.md)	 - Manage payment-methods network-tokens
+

--- a/docs/gr4vy_payment-methods_payment-service-tokens.md
+++ b/docs/gr4vy_payment-methods_payment-service-tokens.md
@@ -1,0 +1,32 @@
+## gr4vy payment-methods payment-service-tokens
+
+Manage payment-methods payment-service-tokens
+
+### Options
+
+```
+  -h, --help   help for payment-service-tokens
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods](gr4vy_payment-methods.md)	 - Manage payment-methods
+* [gr4vy payment-methods payment-service-tokens create](gr4vy_payment-methods_payment-service-tokens_create.md)	 - Create payment service token
+* [gr4vy payment-methods payment-service-tokens delete](gr4vy_payment-methods_payment-service-tokens_delete.md)	 - Delete payment service token
+* [gr4vy payment-methods payment-service-tokens list](gr4vy_payment-methods_payment-service-tokens_list.md)	 - List payment service tokens
+

--- a/docs/gr4vy_payment-methods_payment-service-tokens_create.md
+++ b/docs/gr4vy_payment-methods_payment-service-tokens_create.md
@@ -1,0 +1,40 @@
+## gr4vy payment-methods payment-service-tokens create
+
+Create payment service token
+
+### Synopsis
+
+Create payment service token
+
+Create a gateway tokens for a payment method.
+
+```
+gr4vy payment-methods payment-service-tokens create <payment-method-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PaymentServiceTokenCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods payment-service-tokens](gr4vy_payment-methods_payment-service-tokens.md)	 - Manage payment-methods payment-service-tokens
+

--- a/docs/gr4vy_payment-methods_payment-service-tokens_delete.md
+++ b/docs/gr4vy_payment-methods_payment-service-tokens_delete.md
@@ -1,0 +1,39 @@
+## gr4vy payment-methods payment-service-tokens delete
+
+Delete payment service token
+
+### Synopsis
+
+Delete payment service token
+
+Delete a gateway tokens for a payment method.
+
+```
+gr4vy payment-methods payment-service-tokens delete <payment-method-id> <payment-service-token-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods payment-service-tokens](gr4vy_payment-methods_payment-service-tokens.md)	 - Manage payment-methods payment-service-tokens
+

--- a/docs/gr4vy_payment-methods_payment-service-tokens_list.md
+++ b/docs/gr4vy_payment-methods_payment-service-tokens_list.md
@@ -1,0 +1,40 @@
+## gr4vy payment-methods payment-service-tokens list
+
+List payment service tokens
+
+### Synopsis
+
+List payment service tokens
+
+List all gateway tokens stored for a payment method.
+
+```
+gr4vy payment-methods payment-service-tokens list <payment-method-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help                        help for list
+      --payment-service-id string   payment-service-id parameter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods payment-service-tokens](gr4vy_payment-methods_payment-service-tokens.md)	 - Manage payment-methods payment-service-tokens
+

--- a/docs/gr4vy_payment-methods_update.md
+++ b/docs/gr4vy_payment-methods_update.md
@@ -1,0 +1,40 @@
+## gr4vy payment-methods update
+
+Update payment method
+
+### Synopsis
+
+Update payment method
+
+Update the details of a stored payment method.
+
+```
+gr4vy payment-methods update <payment-method-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PaymentMethodUpdate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-methods](gr4vy_payment-methods.md)	 - Manage payment-methods
+

--- a/docs/gr4vy_payment-options.md
+++ b/docs/gr4vy_payment-options.md
@@ -1,0 +1,30 @@
+## gr4vy payment-options
+
+Manage payment-options
+
+### Options
+
+```
+  -h, --help   help for payment-options
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy payment-options list](gr4vy_payment-options_list.md)	 - List payment options
+

--- a/docs/gr4vy_payment-options_list.md
+++ b/docs/gr4vy_payment-options_list.md
@@ -1,0 +1,40 @@
+## gr4vy payment-options list
+
+List payment options
+
+### Synopsis
+
+List payment options
+
+List the payment options available at checkout. filtering by country, currency, and additional fields passed to Flow rules.
+
+```
+gr4vy payment-options list [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PaymentOptionRequest)
+  -h, --help          help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-options](gr4vy_payment-options.md)	 - Manage payment-options
+

--- a/docs/gr4vy_payment-service-definitions.md
+++ b/docs/gr4vy_payment-service-definitions.md
@@ -1,0 +1,32 @@
+## gr4vy payment-service-definitions
+
+Manage payment-service-definitions
+
+### Options
+
+```
+  -h, --help   help for payment-service-definitions
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy payment-service-definitions get](gr4vy_payment-service-definitions_get.md)	 - Get a payment service definition
+* [gr4vy payment-service-definitions list](gr4vy_payment-service-definitions_list.md)	 - List payment service definitions
+* [gr4vy payment-service-definitions session](gr4vy_payment-service-definitions_session.md)	 - Create a session for a payment service definition
+

--- a/docs/gr4vy_payment-service-definitions_get.md
+++ b/docs/gr4vy_payment-service-definitions_get.md
@@ -1,0 +1,39 @@
+## gr4vy payment-service-definitions get
+
+Get a payment service definition
+
+### Synopsis
+
+Get a payment service definition
+
+Get the definition of a payment service that can be configured.
+
+```
+gr4vy payment-service-definitions get <payment-service-definition-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-service-definitions](gr4vy_payment-service-definitions.md)	 - Manage payment-service-definitions
+

--- a/docs/gr4vy_payment-service-definitions_list.md
+++ b/docs/gr4vy_payment-service-definitions_list.md
@@ -1,0 +1,41 @@
+## gr4vy payment-service-definitions list
+
+List payment service definitions
+
+### Synopsis
+
+List payment service definitions
+
+List the definitions of each payment service that can be configured.
+
+```
+gr4vy payment-service-definitions list [flags]
+```
+
+### Options
+
+```
+      --cursor string   pagination cursor
+  -h, --help            help for list
+      --limit int       maximum number of items to return
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-service-definitions](gr4vy_payment-service-definitions.md)	 - Manage payment-service-definitions
+

--- a/docs/gr4vy_payment-service-definitions_session.md
+++ b/docs/gr4vy_payment-service-definitions_session.md
@@ -1,0 +1,40 @@
+## gr4vy payment-service-definitions session
+
+Create a session for a payment service definition
+
+### Synopsis
+
+Create a session for a payment service definition
+
+Creates a session for a payment service that supports sessions.
+
+```
+gr4vy payment-service-definitions session <payment-service-definition-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin
+  -h, --help          help for session
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-service-definitions](gr4vy_payment-service-definitions.md)	 - Manage payment-service-definitions
+

--- a/docs/gr4vy_payment-services.md
+++ b/docs/gr4vy_payment-services.md
@@ -1,0 +1,36 @@
+## gr4vy payment-services
+
+Manage payment-services
+
+### Options
+
+```
+  -h, --help   help for payment-services
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy payment-services create](gr4vy_payment-services_create.md)	 - Configure a payment service
+* [gr4vy payment-services delete](gr4vy_payment-services_delete.md)	 - Delete a configured payment service
+* [gr4vy payment-services get](gr4vy_payment-services_get.md)	 - Get payment service
+* [gr4vy payment-services list](gr4vy_payment-services_list.md)	 - List payment services
+* [gr4vy payment-services session](gr4vy_payment-services_session.md)	 - Create a session for a payment service definition
+* [gr4vy payment-services update](gr4vy_payment-services_update.md)	 - Update a configured payment service
+* [gr4vy payment-services verify](gr4vy_payment-services_verify.md)	 - Verify payment service credentials
+

--- a/docs/gr4vy_payment-services_create.md
+++ b/docs/gr4vy_payment-services_create.md
@@ -1,0 +1,40 @@
+## gr4vy payment-services create
+
+Configure a payment service
+
+### Synopsis
+
+Configure a payment service
+
+Configures a new payment service for use by merchants.
+
+```
+gr4vy payment-services create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PaymentServiceCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-services](gr4vy_payment-services.md)	 - Manage payment-services
+

--- a/docs/gr4vy_payment-services_delete.md
+++ b/docs/gr4vy_payment-services_delete.md
@@ -1,0 +1,39 @@
+## gr4vy payment-services delete
+
+Delete a configured payment service
+
+### Synopsis
+
+Delete a configured payment service
+
+Deletes all the configuration of a payment service.
+
+```
+gr4vy payment-services delete <payment-service-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-services](gr4vy_payment-services.md)	 - Manage payment-services
+

--- a/docs/gr4vy_payment-services_get.md
+++ b/docs/gr4vy_payment-services_get.md
@@ -1,0 +1,39 @@
+## gr4vy payment-services get
+
+Get payment service
+
+### Synopsis
+
+Get payment service
+
+Get the details of a configured payment service.
+
+```
+gr4vy payment-services get <payment-service-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-services](gr4vy_payment-services.md)	 - Manage payment-services
+

--- a/docs/gr4vy_payment-services_list.md
+++ b/docs/gr4vy_payment-services_list.md
@@ -1,0 +1,43 @@
+## gr4vy payment-services list
+
+List payment services
+
+### Synopsis
+
+List payment services
+
+List the configured payment services.
+
+```
+gr4vy payment-services list [flags]
+```
+
+### Options
+
+```
+      --cursor string   pagination cursor
+      --deleted         deleted parameter
+  -h, --help            help for list
+      --limit int       maximum number of items to return
+      --method string   method parameter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-services](gr4vy_payment-services.md)	 - Manage payment-services
+

--- a/docs/gr4vy_payment-services_session.md
+++ b/docs/gr4vy_payment-services_session.md
@@ -1,0 +1,40 @@
+## gr4vy payment-services session
+
+Create a session for a payment service definition
+
+### Synopsis
+
+Create a session for a payment service definition
+
+Creates a session for a payment service that supports sessions.
+
+```
+gr4vy payment-services session <payment-service-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin
+  -h, --help          help for session
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-services](gr4vy_payment-services.md)	 - Manage payment-services
+

--- a/docs/gr4vy_payment-services_update.md
+++ b/docs/gr4vy_payment-services_update.md
@@ -1,0 +1,40 @@
+## gr4vy payment-services update
+
+Update a configured payment service
+
+### Synopsis
+
+Update a configured payment service
+
+Updates the configuration of a payment service.
+
+```
+gr4vy payment-services update <payment-service-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PaymentServiceUpdate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-services](gr4vy_payment-services.md)	 - Manage payment-services
+

--- a/docs/gr4vy_payment-services_verify.md
+++ b/docs/gr4vy_payment-services_verify.md
@@ -1,0 +1,40 @@
+## gr4vy payment-services verify
+
+Verify payment service credentials
+
+### Synopsis
+
+Verify payment service credentials
+
+Verify the credentials of a configured payment service
+
+```
+gr4vy payment-services verify [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (VerifyCredentials)
+  -h, --help          help for verify
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payment-services](gr4vy_payment-services.md)	 - Manage payment-services
+

--- a/docs/gr4vy_payouts.md
+++ b/docs/gr4vy_payouts.md
@@ -1,0 +1,32 @@
+## gr4vy payouts
+
+Manage payouts
+
+### Options
+
+```
+  -h, --help   help for payouts
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy payouts create](gr4vy_payouts_create.md)	 - Create a payout
+* [gr4vy payouts get](gr4vy_payouts_get.md)	 - Get a payout
+* [gr4vy payouts list](gr4vy_payouts_list.md)	 - List payouts created
+

--- a/docs/gr4vy_payouts_create.md
+++ b/docs/gr4vy_payouts_create.md
@@ -1,0 +1,40 @@
+## gr4vy payouts create
+
+Create a payout
+
+### Synopsis
+
+Create a payout
+
+Creates a new payout.
+
+```
+gr4vy payouts create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (PayoutCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payouts](gr4vy_payouts.md)	 - Manage payouts
+

--- a/docs/gr4vy_payouts_get.md
+++ b/docs/gr4vy_payouts_get.md
@@ -1,0 +1,39 @@
+## gr4vy payouts get
+
+Get a payout
+
+### Synopsis
+
+Get a payout
+
+Retrieves a payout.
+
+```
+gr4vy payouts get <payout-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payouts](gr4vy_payouts.md)	 - Manage payouts
+

--- a/docs/gr4vy_payouts_list.md
+++ b/docs/gr4vy_payouts_list.md
@@ -1,0 +1,41 @@
+## gr4vy payouts list
+
+List payouts created
+
+### Synopsis
+
+List payouts created
+
+Returns a list of payouts made.
+
+```
+gr4vy payouts list [flags]
+```
+
+### Options
+
+```
+      --cursor string   pagination cursor
+  -h, --help            help for list
+      --limit int       maximum number of items to return
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy payouts](gr4vy_payouts.md)	 - Manage payouts
+

--- a/docs/gr4vy_refunds.md
+++ b/docs/gr4vy_refunds.md
@@ -1,0 +1,30 @@
+## gr4vy refunds
+
+Manage refunds
+
+### Options
+
+```
+  -h, --help   help for refunds
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy refunds get](gr4vy_refunds_get.md)	 - Get refund
+

--- a/docs/gr4vy_refunds_get.md
+++ b/docs/gr4vy_refunds_get.md
@@ -1,0 +1,39 @@
+## gr4vy refunds get
+
+Get refund
+
+### Synopsis
+
+Get refund
+
+Fetch a refund.
+
+```
+gr4vy refunds get <refund-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy refunds](gr4vy_refunds.md)	 - Manage refunds
+

--- a/docs/gr4vy_report-executions.md
+++ b/docs/gr4vy_report-executions.md
@@ -1,0 +1,30 @@
+## gr4vy report-executions
+
+Manage report-executions
+
+### Options
+
+```
+  -h, --help   help for report-executions
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy report-executions list](gr4vy_report-executions_list.md)	 - List executed reports
+

--- a/docs/gr4vy_report-executions_list.md
+++ b/docs/gr4vy_report-executions_list.md
@@ -1,0 +1,43 @@
+## gr4vy report-executions list
+
+List executed reports
+
+### Synopsis
+
+List executed reports
+
+List all executed reports that have been generated.
+
+```
+gr4vy report-executions list [flags]
+```
+
+### Options
+
+```
+      --creator-id strings   creator-id parameter
+      --cursor string        pagination cursor
+  -h, --help                 help for list
+      --limit int            maximum number of items to return
+      --report-name string   report-name parameter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy report-executions](gr4vy_report-executions.md)	 - Manage report-executions
+

--- a/docs/gr4vy_reports.md
+++ b/docs/gr4vy_reports.md
@@ -1,0 +1,34 @@
+## gr4vy reports
+
+Manage reports
+
+### Options
+
+```
+  -h, --help   help for reports
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy reports create](gr4vy_reports_create.md)	 - Add a report
+* [gr4vy reports executions](gr4vy_reports_executions.md)	 - Manage reports executions
+* [gr4vy reports get](gr4vy_reports_get.md)	 - Get a report
+* [gr4vy reports list](gr4vy_reports_list.md)	 - List configured reports
+* [gr4vy reports put](gr4vy_reports_put.md)	 - Update a report
+

--- a/docs/gr4vy_reports_create.md
+++ b/docs/gr4vy_reports_create.md
@@ -1,0 +1,40 @@
+## gr4vy reports create
+
+Add a report
+
+### Synopsis
+
+Add a report
+
+Create a new report.
+
+```
+gr4vy reports create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (ReportCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy reports](gr4vy_reports.md)	 - Manage reports
+

--- a/docs/gr4vy_reports_executions.md
+++ b/docs/gr4vy_reports_executions.md
@@ -1,0 +1,32 @@
+## gr4vy reports executions
+
+Manage reports executions
+
+### Options
+
+```
+  -h, --help   help for executions
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy reports](gr4vy_reports.md)	 - Manage reports
+* [gr4vy reports executions get](gr4vy_reports_executions_get.md)	 - Get executed report
+* [gr4vy reports executions list](gr4vy_reports_executions_list.md)	 - List executions for report
+* [gr4vy reports executions url](gr4vy_reports_executions_url.md)	 - Create URL for executed report
+

--- a/docs/gr4vy_reports_executions_get.md
+++ b/docs/gr4vy_reports_executions_get.md
@@ -1,0 +1,39 @@
+## gr4vy reports executions get
+
+Get executed report
+
+### Synopsis
+
+Get executed report
+
+Fetch a specific executed report.
+
+```
+gr4vy reports executions get <report-execution-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy reports executions](gr4vy_reports_executions.md)	 - Manage reports executions
+

--- a/docs/gr4vy_reports_executions_list.md
+++ b/docs/gr4vy_reports_executions_list.md
@@ -1,0 +1,41 @@
+## gr4vy reports executions list
+
+List executions for report
+
+### Synopsis
+
+List executions for report
+
+List all executions of a specific report.
+
+```
+gr4vy reports executions list <report-id> [flags]
+```
+
+### Options
+
+```
+      --cursor string   pagination cursor
+  -h, --help            help for list
+      --limit int       maximum number of items to return
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy reports executions](gr4vy_reports_executions.md)	 - Manage reports executions
+

--- a/docs/gr4vy_reports_executions_url.md
+++ b/docs/gr4vy_reports_executions_url.md
@@ -1,0 +1,40 @@
+## gr4vy reports executions url
+
+Create URL for executed report
+
+### Synopsis
+
+Create URL for executed report
+
+Creates a download URL for a specific execution of a report.
+
+```
+gr4vy reports executions url <report-id> <report-execution-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (ReportExecutionURLGenerate)
+  -h, --help          help for url
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy reports executions](gr4vy_reports_executions.md)	 - Manage reports executions
+

--- a/docs/gr4vy_reports_get.md
+++ b/docs/gr4vy_reports_get.md
@@ -1,0 +1,39 @@
+## gr4vy reports get
+
+Get a report
+
+### Synopsis
+
+Get a report
+
+Fetches a report by its ID.
+
+```
+gr4vy reports get <report-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy reports](gr4vy_reports.md)	 - Manage reports
+

--- a/docs/gr4vy_reports_list.md
+++ b/docs/gr4vy_reports_list.md
@@ -1,0 +1,43 @@
+## gr4vy reports list
+
+List configured reports
+
+### Synopsis
+
+List configured reports
+
+List all configured reports that can be generated.
+
+```
+gr4vy reports list [flags]
+```
+
+### Options
+
+```
+      --cursor string      pagination cursor
+  -h, --help               help for list
+      --limit int          maximum number of items to return
+      --name string        name parameter
+      --schedule-enabled   schedule-enabled parameter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy reports](gr4vy_reports.md)	 - Manage reports
+

--- a/docs/gr4vy_reports_put.md
+++ b/docs/gr4vy_reports_put.md
@@ -1,0 +1,40 @@
+## gr4vy reports put
+
+Update a report
+
+### Synopsis
+
+Update a report
+
+Updates the configuration of a report.
+
+```
+gr4vy reports put <report-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (ReportUpdate)
+  -h, --help          help for put
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy reports](gr4vy_reports.md)	 - Manage reports
+

--- a/docs/gr4vy_three-ds-scenarios.md
+++ b/docs/gr4vy_three-ds-scenarios.md
@@ -1,0 +1,33 @@
+## gr4vy three-ds-scenarios
+
+Manage three-ds-scenarios
+
+### Options
+
+```
+  -h, --help   help for three-ds-scenarios
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy three-ds-scenarios create](gr4vy_three-ds-scenarios_create.md)	 - Create a 3DS scenario
+* [gr4vy three-ds-scenarios delete](gr4vy_three-ds-scenarios_delete.md)	 - Delete a 3DS scenario
+* [gr4vy three-ds-scenarios list](gr4vy_three-ds-scenarios_list.md)	 - List 3DS scenario
+* [gr4vy three-ds-scenarios update](gr4vy_three-ds-scenarios_update.md)	 - Update a 3DS scenario
+

--- a/docs/gr4vy_three-ds-scenarios_create.md
+++ b/docs/gr4vy_three-ds-scenarios_create.md
@@ -1,0 +1,40 @@
+## gr4vy three-ds-scenarios create
+
+Create a 3DS scenario
+
+### Synopsis
+
+Create a 3DS scenario
+
+Create a new 3DS scenario for a merchant account. Only available in sandbox environments.
+
+```
+gr4vy three-ds-scenarios create [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (ThreeDSecureScenarioCreate)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy three-ds-scenarios](gr4vy_three-ds-scenarios.md)	 - Manage three-ds-scenarios
+

--- a/docs/gr4vy_three-ds-scenarios_delete.md
+++ b/docs/gr4vy_three-ds-scenarios_delete.md
@@ -1,0 +1,39 @@
+## gr4vy three-ds-scenarios delete
+
+Delete a 3DS scenario
+
+### Synopsis
+
+Delete a 3DS scenario
+
+Removes a 3DS scenario from our system. Only available in sandbox environments.
+
+```
+gr4vy three-ds-scenarios delete <three-ds-scenario-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy three-ds-scenarios](gr4vy_three-ds-scenarios.md)	 - Manage three-ds-scenarios
+

--- a/docs/gr4vy_three-ds-scenarios_list.md
+++ b/docs/gr4vy_three-ds-scenarios_list.md
@@ -1,0 +1,41 @@
+## gr4vy three-ds-scenarios list
+
+List 3DS scenario
+
+### Synopsis
+
+List 3DS scenario
+
+List all 3DS scenarios for a merchant account. Only available in sandbox environments.
+
+```
+gr4vy three-ds-scenarios list [flags]
+```
+
+### Options
+
+```
+      --cursor string   pagination cursor
+  -h, --help            help for list
+      --limit int       maximum number of items to return
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy three-ds-scenarios](gr4vy_three-ds-scenarios.md)	 - Manage three-ds-scenarios
+

--- a/docs/gr4vy_three-ds-scenarios_update.md
+++ b/docs/gr4vy_three-ds-scenarios_update.md
@@ -1,0 +1,40 @@
+## gr4vy three-ds-scenarios update
+
+Update a 3DS scenario
+
+### Synopsis
+
+Update a 3DS scenario
+
+Update a 3DS scenario. Only available in sandbox environments.
+
+```
+gr4vy three-ds-scenarios update <three-ds-scenario-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (ThreeDSecureScenarioUpdate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy three-ds-scenarios](gr4vy_three-ds-scenarios.md)	 - Manage three-ds-scenarios
+

--- a/docs/gr4vy_token.md
+++ b/docs/gr4vy_token.md
@@ -1,0 +1,40 @@
+## gr4vy token
+
+Generate a server-to-server API access token (JWT)
+
+### Synopsis
+
+Generate a signed bearer token for the Gr4vy API using the profile's private key. Scopes default to the profile's default_scopes (or *.read and *.write).
+
+```
+gr4vy token [flags]
+```
+
+### Options
+
+```
+  -e, --expires-in string   token lifetime, e.g. 1h, 30m, 10d, 3600 (default 1h)
+  -h, --help                help for token
+      --list-scopes         list all valid scopes and exit
+  -s, --scope strings       scope to include (repeatable); see --list-scopes
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+

--- a/docs/gr4vy_transactions.md
+++ b/docs/gr4vy_transactions.md
@@ -1,0 +1,42 @@
+## gr4vy transactions
+
+Manage transactions
+
+### Options
+
+```
+  -h, --help   help for transactions
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+* [gr4vy transactions actions](gr4vy_transactions_actions.md)	 - Manage transactions actions
+* [gr4vy transactions cancel](gr4vy_transactions_cancel.md)	 - Cancel transaction
+* [gr4vy transactions capture](gr4vy_transactions_capture.md)	 - Capture transaction
+* [gr4vy transactions captures](gr4vy_transactions_captures.md)	 - Manage transactions captures
+* [gr4vy transactions create](gr4vy_transactions_create.md)	 - Create transaction
+* [gr4vy transactions events](gr4vy_transactions_events.md)	 - Manage transactions events
+* [gr4vy transactions get](gr4vy_transactions_get.md)	 - Get transaction
+* [gr4vy transactions list](gr4vy_transactions_list.md)	 - List transactions
+* [gr4vy transactions refunds](gr4vy_transactions_refunds.md)	 - Manage transactions refunds
+* [gr4vy transactions settlements](gr4vy_transactions_settlements.md)	 - Manage transactions settlements
+* [gr4vy transactions sync](gr4vy_transactions_sync.md)	 - Sync transaction
+* [gr4vy transactions update](gr4vy_transactions_update.md)	 - Manually update a transaction
+* [gr4vy transactions void](gr4vy_transactions_void.md)	 - Void transaction
+

--- a/docs/gr4vy_transactions_actions.md
+++ b/docs/gr4vy_transactions_actions.md
@@ -1,0 +1,30 @@
+## gr4vy transactions actions
+
+Manage transactions actions
+
+### Options
+
+```
+  -h, --help   help for actions
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+* [gr4vy transactions actions list](gr4vy_transactions_actions_list.md)	 - List transaction Flow rules
+

--- a/docs/gr4vy_transactions_actions_list.md
+++ b/docs/gr4vy_transactions_actions_list.md
@@ -1,0 +1,39 @@
+## gr4vy transactions actions list
+
+List transaction Flow rules
+
+### Synopsis
+
+List transaction Flow rules
+
+Retrieve the list of Flow rule actions that have been triggered for a transaction.
+
+```
+gr4vy transactions actions list <transaction-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions actions](gr4vy_transactions_actions.md)	 - Manage transactions actions
+

--- a/docs/gr4vy_transactions_cancel.md
+++ b/docs/gr4vy_transactions_cancel.md
@@ -1,0 +1,39 @@
+## gr4vy transactions cancel
+
+Cancel transaction
+
+### Synopsis
+
+Cancel transaction
+
+Cancels a pending transaction. If the transaction was successfully authorized, or was already captured, the cancel will not be processed.
+
+```
+gr4vy transactions cancel <transaction-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for cancel
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+

--- a/docs/gr4vy_transactions_capture.md
+++ b/docs/gr4vy_transactions_capture.md
@@ -1,0 +1,42 @@
+## gr4vy transactions capture
+
+Capture transaction
+
+### Synopsis
+
+Capture transaction
+
+Captures a previously authorized transaction. You can capture the full or a partial amount, as long as it does not exceed the authorized amount (unless over-capture is enabled).
+
+```
+gr4vy transactions capture <transaction-id> [flags]
+```
+
+### Options
+
+```
+      --data string              request body as JSON: inline, @file, or - for stdin (TransactionCaptureCreate)
+  -h, --help                     help for capture
+      --idempotency-key string   unique key to make the request idempotent
+      --prefer strings           preferred response resource type
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+

--- a/docs/gr4vy_transactions_captures.md
+++ b/docs/gr4vy_transactions_captures.md
@@ -1,0 +1,31 @@
+## gr4vy transactions captures
+
+Manage transactions captures
+
+### Options
+
+```
+  -h, --help   help for captures
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+* [gr4vy transactions captures get](gr4vy_transactions_captures_get.md)	 - Get transaction capture
+* [gr4vy transactions captures list](gr4vy_transactions_captures_list.md)	 - List transaction captures
+

--- a/docs/gr4vy_transactions_captures_get.md
+++ b/docs/gr4vy_transactions_captures_get.md
@@ -1,0 +1,39 @@
+## gr4vy transactions captures get
+
+Get transaction capture
+
+### Synopsis
+
+Get transaction capture
+
+Retrieve a specific capture for a transaction by its unique identifier.
+
+```
+gr4vy transactions captures get <transaction-id> <capture-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions captures](gr4vy_transactions_captures.md)	 - Manage transactions captures
+

--- a/docs/gr4vy_transactions_captures_list.md
+++ b/docs/gr4vy_transactions_captures_list.md
@@ -1,0 +1,39 @@
+## gr4vy transactions captures list
+
+List transaction captures
+
+### Synopsis
+
+List transaction captures
+
+List all captures for a specific transaction.
+
+```
+gr4vy transactions captures list <transaction-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions captures](gr4vy_transactions_captures.md)	 - Manage transactions captures
+

--- a/docs/gr4vy_transactions_create.md
+++ b/docs/gr4vy_transactions_create.md
@@ -1,0 +1,42 @@
+## gr4vy transactions create
+
+Create transaction
+
+### Synopsis
+
+Create transaction
+
+Create a new transaction using a supported payment method. If additional buyer authorization is required, an approval URL will be returned. Duplicated gift card numbers are not supported.
+
+```
+gr4vy transactions create [flags]
+```
+
+### Options
+
+```
+      --data string              request body as JSON: inline, @file, or - for stdin (TransactionCreate)
+  -h, --help                     help for create
+      --idempotency-key string   unique key to make the request idempotent
+      --x-forwarded-for string   originating client IP address
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+

--- a/docs/gr4vy_transactions_events.md
+++ b/docs/gr4vy_transactions_events.md
@@ -1,0 +1,30 @@
+## gr4vy transactions events
+
+Manage transactions events
+
+### Options
+
+```
+  -h, --help   help for events
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+* [gr4vy transactions events list](gr4vy_transactions_events_list.md)	 - List transaction events
+

--- a/docs/gr4vy_transactions_events_list.md
+++ b/docs/gr4vy_transactions_events_list.md
@@ -1,0 +1,41 @@
+## gr4vy transactions events list
+
+List transaction events
+
+### Synopsis
+
+List transaction events
+
+Retrieve a paginated list of events related to processing a transaction, including status changes, API requests, and webhook delivery attempts. Events are listed in chronological order, with the most recent events first.
+
+```
+gr4vy transactions events list <transaction-id> [flags]
+```
+
+### Options
+
+```
+      --cursor string   pagination cursor
+  -h, --help            help for list
+      --limit int       maximum number of items to return
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions events](gr4vy_transactions_events.md)	 - Manage transactions events
+

--- a/docs/gr4vy_transactions_get.md
+++ b/docs/gr4vy_transactions_get.md
@@ -1,0 +1,39 @@
+## gr4vy transactions get
+
+Get transaction
+
+### Synopsis
+
+Get transaction
+
+Retrieve the details of a transaction by its unique identifier.
+
+```
+gr4vy transactions get <transaction-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+

--- a/docs/gr4vy_transactions_list.md
+++ b/docs/gr4vy_transactions_list.md
@@ -1,0 +1,76 @@
+## gr4vy transactions list
+
+List transactions
+
+### Synopsis
+
+List transactions
+
+Returns a paginated list of transactions for the merchant account, sorted by most recently updated. You can filter, sort, and search transactions using query parameters.
+
+```
+gr4vy transactions list [flags]
+```
+
+### Options
+
+```
+      --amount-eq int                             amount-eq parameter
+      --amount-gte int                            amount-gte parameter
+      --amount-lte int                            amount-lte parameter
+      --buyer-email-address string                buyer-email-address parameter
+      --buyer-external-identifier string          buyer-external-identifier parameter
+      --buyer-id string                           buyer-id parameter
+      --buyer-search strings                      buyer-search parameter
+      --checkout-session-id string                checkout-session-id parameter
+      --country strings                           country parameter
+      --currency strings                          currency parameter
+      --cursor string                             pagination cursor
+      --disputed                                  disputed parameter
+      --error-code strings                        error-code parameter
+      --external-identifier string                external-identifier parameter
+      --gift-card-id string                       gift-card-id parameter
+      --gift-card-last4 string                    gift-card-last4 parameter
+      --has-gift-card-redemptions                 has-gift-card-redemptions parameter
+      --has-refunds                               has-refunds parameter
+      --has-settlements                           has-settlements parameter
+  -h, --help                                      help for list
+      --id string                                 id parameter
+      --ip-address string                         ip-address parameter
+      --is-subsequent-payment                     is-subsequent-payment parameter
+      --limit int                                 maximum number of items to return
+      --merchant-initiated                        merchant-initiated parameter
+      --metadata strings                          metadata parameter
+      --payment-method-bin string                 payment-method-bin parameter
+      --payment-method-country string             payment-method-country parameter
+      --payment-method-fingerprint string         payment-method-fingerprint parameter
+      --payment-method-id string                  payment-method-id parameter
+      --payment-method-label string               payment-method-label parameter
+      --payment-method-scheme strings             payment-method-scheme parameter
+      --payment-service-id strings                payment-service-id parameter
+      --payment-service-transaction-id string     payment-service-transaction-id parameter
+      --pending-review                            pending-review parameter
+      --reauthorized-from-transaction-id string   reauthorized-from-transaction-id parameter
+      --reconciliation-id string                  reconciliation-id parameter
+      --search string                             free-text search filter
+      --used-3ds                                  used-3ds parameter
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+

--- a/docs/gr4vy_transactions_refunds.md
+++ b/docs/gr4vy_transactions_refunds.md
@@ -1,0 +1,33 @@
+## gr4vy transactions refunds
+
+Manage transactions refunds
+
+### Options
+
+```
+  -h, --help   help for refunds
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+* [gr4vy transactions refunds all](gr4vy_transactions_refunds_all.md)	 - Manage transactions refunds all
+* [gr4vy transactions refunds create](gr4vy_transactions_refunds_create.md)	 - Create transaction refund
+* [gr4vy transactions refunds get](gr4vy_transactions_refunds_get.md)	 - Get transaction refund
+* [gr4vy transactions refunds list](gr4vy_transactions_refunds_list.md)	 - List transaction refunds
+

--- a/docs/gr4vy_transactions_refunds_all.md
+++ b/docs/gr4vy_transactions_refunds_all.md
@@ -1,0 +1,30 @@
+## gr4vy transactions refunds all
+
+Manage transactions refunds all
+
+### Options
+
+```
+  -h, --help   help for all
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions refunds](gr4vy_transactions_refunds.md)	 - Manage transactions refunds
+* [gr4vy transactions refunds all create](gr4vy_transactions_refunds_all_create.md)	 - Create batch transaction refund
+

--- a/docs/gr4vy_transactions_refunds_all_create.md
+++ b/docs/gr4vy_transactions_refunds_all_create.md
@@ -1,0 +1,41 @@
+## gr4vy transactions refunds all create
+
+Create batch transaction refund
+
+### Synopsis
+
+Create batch transaction refund
+
+Create a refund for all instruments on a transaction.
+
+```
+gr4vy transactions refunds all create <transaction-id> [flags]
+```
+
+### Options
+
+```
+      --data string              request body as JSON: inline, @file, or - for stdin (TransactionRefundAllCreate)
+  -h, --help                     help for create
+      --idempotency-key string   unique key to make the request idempotent
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions refunds all](gr4vy_transactions_refunds_all.md)	 - Manage transactions refunds all
+

--- a/docs/gr4vy_transactions_refunds_create.md
+++ b/docs/gr4vy_transactions_refunds_create.md
@@ -1,0 +1,41 @@
+## gr4vy transactions refunds create
+
+Create transaction refund
+
+### Synopsis
+
+Create transaction refund
+
+Create a refund for a transaction.
+
+```
+gr4vy transactions refunds create <transaction-id> [flags]
+```
+
+### Options
+
+```
+      --data string              request body as JSON: inline, @file, or - for stdin (TransactionRefundCreate)
+  -h, --help                     help for create
+      --idempotency-key string   unique key to make the request idempotent
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions refunds](gr4vy_transactions_refunds.md)	 - Manage transactions refunds
+

--- a/docs/gr4vy_transactions_refunds_get.md
+++ b/docs/gr4vy_transactions_refunds_get.md
@@ -1,0 +1,39 @@
+## gr4vy transactions refunds get
+
+Get transaction refund
+
+### Synopsis
+
+Get transaction refund
+
+Fetch refund for a transaction.
+
+```
+gr4vy transactions refunds get <transaction-id> <refund-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions refunds](gr4vy_transactions_refunds.md)	 - Manage transactions refunds
+

--- a/docs/gr4vy_transactions_refunds_list.md
+++ b/docs/gr4vy_transactions_refunds_list.md
@@ -1,0 +1,39 @@
+## gr4vy transactions refunds list
+
+List transaction refunds
+
+### Synopsis
+
+List transaction refunds
+
+List refunds for a transaction.
+
+```
+gr4vy transactions refunds list <transaction-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions refunds](gr4vy_transactions_refunds.md)	 - Manage transactions refunds
+

--- a/docs/gr4vy_transactions_settlements.md
+++ b/docs/gr4vy_transactions_settlements.md
@@ -1,0 +1,31 @@
+## gr4vy transactions settlements
+
+Manage transactions settlements
+
+### Options
+
+```
+  -h, --help   help for settlements
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+* [gr4vy transactions settlements get](gr4vy_transactions_settlements_get.md)	 - Get transaction settlement
+* [gr4vy transactions settlements list](gr4vy_transactions_settlements_list.md)	 - List transaction settlements
+

--- a/docs/gr4vy_transactions_settlements_get.md
+++ b/docs/gr4vy_transactions_settlements_get.md
@@ -1,0 +1,39 @@
+## gr4vy transactions settlements get
+
+Get transaction settlement
+
+### Synopsis
+
+Get transaction settlement
+
+Retrieve a specific settlement for a transaction by its unique identifier.
+
+```
+gr4vy transactions settlements get <transaction-id> <settlement-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions settlements](gr4vy_transactions_settlements.md)	 - Manage transactions settlements
+

--- a/docs/gr4vy_transactions_settlements_list.md
+++ b/docs/gr4vy_transactions_settlements_list.md
@@ -1,0 +1,39 @@
+## gr4vy transactions settlements list
+
+List transaction settlements
+
+### Synopsis
+
+List transaction settlements
+
+List all settlements for a specific transaction.
+
+```
+gr4vy transactions settlements list <transaction-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions settlements](gr4vy_transactions_settlements.md)	 - Manage transactions settlements
+

--- a/docs/gr4vy_transactions_sync.md
+++ b/docs/gr4vy_transactions_sync.md
@@ -1,0 +1,39 @@
+## gr4vy transactions sync
+
+Sync transaction
+
+### Synopsis
+
+Sync transaction
+
+Synchronizes the status of a transaction with the underlying payment service provider. This is useful for transactions in a pending state to check if they've been completed or failed. Only available for some payment service providers.
+
+```
+gr4vy transactions sync <transaction-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for sync
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+

--- a/docs/gr4vy_transactions_update.md
+++ b/docs/gr4vy_transactions_update.md
@@ -1,0 +1,40 @@
+## gr4vy transactions update
+
+Manually update a transaction
+
+### Synopsis
+
+Manually update a transaction
+
+Manually updates a transaction.
+
+```
+gr4vy transactions update <transaction-id> [flags]
+```
+
+### Options
+
+```
+      --data string   request body as JSON: inline, @file, or - for stdin (TransactionUpdate)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+

--- a/docs/gr4vy_transactions_void.md
+++ b/docs/gr4vy_transactions_void.md
@@ -1,0 +1,41 @@
+## gr4vy transactions void
+
+Void transaction
+
+### Synopsis
+
+Void transaction
+
+Voids a previously authorized transaction. If the transaction was not yet successfully authorized, or was already captured, the void will not be processed. This operation releases the hold on the buyer's funds. Captured transactions can be refunded instead.
+
+```
+gr4vy transactions void <transaction-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for void
+      --idempotency-key string   unique key to make the request idempotent
+      --prefer strings           preferred response resource type
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy transactions](gr4vy_transactions.md)	 - Manage transactions
+

--- a/docs/gr4vy_version.md
+++ b/docs/gr4vy_version.md
@@ -1,0 +1,33 @@
+## gr4vy version
+
+Print the CLI version
+
+```
+gr4vy version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+      --compact                      compact single-line JSON output
+      --config string                path to the config file (env: GR4VY_CONFIG)
+      --debug                        print debug information to stderr
+      --id string                    Gr4vy instance id used for the API host (env: GR4VY_ID)
+      --merchant-account-id string   merchant account id (env: GR4VY_MERCHANT_ACCOUNT_ID)
+  -o, --output string                output format: json|yaml|table (env: GR4VY_OUTPUT)
+      --profile string               configuration profile to use (env: GR4VY_PROFILE)
+      --server string                server environment: sandbox|production (env: GR4VY_SERVER)
+      --timeout duration             per-request timeout, e.g. 30s
+      --token string                 pre-generated bearer token; skips JWT signing (env: GR4VY_TOKEN)
+```
+
+### SEE ALSO
+
+* [gr4vy](gr4vy.md)	 - The Gr4vy CLI
+

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,15 @@ require (
 )
 
 require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spyzhov/ajson v0.8.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
@@ -19,6 +20,7 @@ github.com/pelletier/go-toml/v2 v2.4.0 h1:Mwu0mAkUKbittDs3/ADDWXqMmq3EOK2VHiuCkV
 github.com/pelletier/go-toml/v2 v2.4.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
@@ -33,6 +35,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=

--- a/internal/gendocs/main.go
+++ b/internal/gendocs/main.go
@@ -1,0 +1,38 @@
+// Command gendocs renders a Markdown reference for the whole gr4vy command tree
+// into ./docs, using cobra's doc generator. Run via `go generate ./...` /
+// `go run ./internal/gendocs`; it is never compiled into the shipped binary.
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+
+	"github.com/gr4vy/gr4vy-cli/internal/cli"
+)
+
+const outDir = "docs"
+
+func main() {
+	root := cli.NewRootCmd()
+	root.DisableAutoGenTag = true // deterministic output (no generation date)
+	disableAutoGenTag(root)
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		log.Fatalf("gendocs: %v", err)
+	}
+	if err := doc.GenMarkdownTree(root, outDir); err != nil {
+		log.Fatalf("gendocs: %v", err)
+	}
+}
+
+// disableAutoGenTag turns off cobra's "Auto generated … on <date>" footer for
+// every command so regeneration is deterministic (no date churn in diffs).
+func disableAutoGenTag(c *cobra.Command) {
+	c.DisableAutoGenTag = true
+	for _, sub := range c.Commands() {
+		disableAutoGenTag(sub)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@
 package main
 
 //go:generate go run ./internal/gen
+//go:generate go run ./internal/gendocs
 
 import "github.com/gr4vy/gr4vy-cli/internal/cli"
 


### PR DESCRIPTION
Addresses three gaps: sparse command docs, undocumented output formats, and undocumented autocomplete.

## 1. Autogenerated command reference
Adds `internal/gendocs`, which uses **cobra's built-in `doc` generator** to render a Markdown page for every command (162 pages) into [`docs/`](docs/gr4vy.md) — each with the command's synopsis (from the SDK method's doc comment), arguments, flags, inherited globals, and links to sub/parent commands.

- Wired into `go generate ./...` (after the command generator) and `make docs`.
- Deterministic output (cobra's autogen date tag disabled), so diffs are clean.
- The CI "generation up to date" check now also covers `docs/`, and the `regen` workflow regenerates it alongside the commands — so the reference can never drift from the command surface.

## 2. Output formats
Documented in the README. Note: the `-o json|yaml|table` / `--compact` / `GR4VY_OUTPUT` formatting is the CLI's own feature (`internal/output`), not a cobra feature, so it's documented directly here (per-command pages also list the inherited `--output` flag).

## 3. Shell completion
Already built in via cobra (the `completion` command). Now documented in the README for bash/zsh/fish/PowerShell, including that fixed-choice flags (e.g. `token --scope`) complete their values.

Verified: builds, `go vet`, all tests pass, and doc generation is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)