### PR TITLE
ci: stop Dependabot PRs from failing e2e/auto-merge

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -23,6 +23,9 @@ permissions:
 
 jobs:
   auto-merge:
+    # Dependabot-triggered runs don't have access to DISPATCH_ACCESS_TOKEN and
+    # only ever produce non-bot PRs, so skip them (they'd otherwise error).
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       # Belt-and-suspenders approval (the gr4vy-code merge already bypasses the

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,10 +30,13 @@ jobs:
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          IS_DEPENDABOT: ${{ github.actor == 'dependabot[bot]' || github.event.pull_request.user.login == 'dependabot[bot]' }}
           REQUIRE_E2E: ${{ vars.REQUIRE_E2E }}
         run: |
           if [ -z "$PRIVATE_KEY" ]; then
-            if [ "$REQUIRE_E2E" = "true" ] && [ "$IS_FORK_PR" != "true" ]; then
+            # Fork and Dependabot PRs run without repo secrets, so the live suite
+            # can't run there — skip rather than fail.
+            if [ "$REQUIRE_E2E" = "true" ] && [ "$IS_FORK_PR" != "true" ] && [ "$IS_DEPENDABOT" != "true" ]; then
               echo "::error::PRIVATE_KEY is not set on a trusted ref (REQUIRE_E2E=true)."
               exit 1
             fi


### PR DESCRIPTION
Dependabot PRs run without access to repository secrets, which made #67 (and every future Dependabot PR) show red:
- **e2e** hard-failed because `PRIVATE_KEY` is absent and `REQUIRE_E2E=true` only exempted fork PRs → now also exempts Dependabot (skips, like forks).
- **auto-merge** errored with `GITHUB_TOKEN not set` (no `DISPATCH_ACCESS_TOKEN` on Dependabot runs) → the job now skips for `dependabot[bot]` (it only ever targets the release/regen PRs anyway).

The required check (`ci-complete`) was always green, so the bumps themselves were fine; this just removes the noise so Dependabot PRs are cleanly mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)