### PR TITLE
chore: point Scoop bucket at renamed gr4vy-scoop-bucket repo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,11 +50,11 @@ brews:
     test: |
       system "#{bin}/gr4vy version"
 
-# Scoop bucket for Windows (optional; requires gr4vy/scoop-bucket).
+# Scoop bucket for Windows (optional; requires gr4vy/gr4vy-scoop-bucket).
 scoops:
   - repository:
       owner: gr4vy
-      name: scoop-bucket
+      name: gr4vy-scoop-bucket
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: "https://github.com/gr4vy/gr4vy-cli"
     description: "The Gr4vy command-line interface"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ brew install gr4vy/tap/gr4vy
 ### Scoop (Windows)
 
 ```powershell
-scoop bucket add gr4vy https://github.com/gr4vy/scoop-bucket
+scoop bucket add gr4vy https://github.com/gr4vy/gr4vy-scoop-bucket
 scoop install gr4vy
 ```
 


### PR DESCRIPTION
## What

The `gr4vy/scoop-bucket` repo has been renamed to [`gr4vy/gr4vy-scoop-bucket`](https://github.com/gr4vy/gr4vy-scoop-bucket) for clarity/consistency, and given a proper description + README that links back to the CLI.

This PR updates the two references in this repo so nothing relies on GitHub's rename redirect long-term:

- `.goreleaser.yaml` — goreleaser's Scoop publish target (`name: gr4vy-scoop-bucket`)
- `README.md` — the `scoop bucket add` install command

## Release process

GitHub auto-redirects the old name for git push + API, so releases would keep working even without this change — but the redirect would break if anyone ever recreated a repo named `scoop-bucket`. Updating both references removes that dependency. The `HOMEBREW_TAP_TOKEN` follows the repo through the rename, so no token/secret changes are needed.

Existing users who already ran `scoop bucket add gr4vy https://github.com/gr4vy/scoop-bucket` continue to work via the same redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)