### PR TITLE
ci: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/failureNotifications.yml
+++ b/.github/workflows/failureNotifications.yml
@@ -15,12 +15,11 @@ jobs:
     steps:
       - name: Announce Failure
         id: slack
-        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # v1.21.0
-        env:
-          # for non-CLI-team-owned plugins, you can send this anywhere you like
-          SLACK_WEBHOOK_URL: ${{ secrets.CLI_ALERTS_SLACK_WEBHOOK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
+          # for non-CLI-team-owned plugins, you can send this anywhere you like
+          webhook: ${{ secrets.CLI_ALERTS_SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "${{ github.event.workflow_run.name }} failed: ${{ github.event.workflow_run.repository.name }}",

--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -18,7 +18,7 @@ jobs:
   regen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Use a token whose pushes trigger CI on the resulting PR.
           token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
@@ -26,7 +26,7 @@ jobs:
           # extraheader would otherwise collide and cause a duplicate
           # Authorization header (HTTP 400) since actions/checkout v5+.
           persist-credentials: false
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,14 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
## Summary

Consolidates the four open Dependabot GitHub Actions PRs into one, so they can all be reviewed and merged together. Closes #79, #102, #103, #111.

All actions remain SHA-pinned with a version comment.

| Action | From | To |
| --- | --- | --- |
| actions/checkout | v7.0.0 | v7.0.1 |
| actions/setup-go | v5 (5.6.0) | **v7.0.0** |
| goreleaser/goreleaser-action | v6 | **v7.2.3** |
| slackapi/slack-github-action | v1.21.0 | **v4.0.0** |

## Breaking-change handling

- **slack-github-action v2+** dropped the `SLACK_WEBHOOK_URL` / `SLACK_WEBHOOK_TYPE` env-var form for incoming webhooks. The failure-notification step in `failureNotifications.yml` is migrated to the documented `webhook` + `webhook-type: incoming-webhook` inputs. The Block Kit `payload` is unchanged.
- **setup-go v7** and **goreleaser-action v7** majors only bumped their Node runtime (Node 24) — no input API changes — so those steps are otherwise untouched. `go-version-file`, `cache`, `version: "~> v2"` and `args` all remain valid.

## Verification

- All workflow YAML validated as well-formed.
- `actions/checkout` and `actions/setup-go` are exercised directly by this PR's own `ci` run.
- `goreleaser` (tag-push only) and `slack` (workflow-failure only) are not triggered by PR CI — verified against their release notes / docs instead of runtime.

## Note

Once merged, Dependabot should auto-close #79, #102, #103 and #111. I've left them open for now; happy to close them explicitly on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)