### PR TITLE
ci: update Renovate-pinned GitHub Actions

### DIFF
--- a/.github/workflows/notify-slack-on-pr-open.yml
+++ b/.github/workflows/notify-slack-on-pr-open.yml
@@ -20,4 +20,4 @@ jobs:
         PULL_REQUEST_REPO: ${{ github.event.pull_request.head.repo.name }}
         PULL_REQUEST_TITLE : ${{ github.event.pull_request.title }}
         PULL_REQUEST_URL : ${{ github.event.pull_request.html_url }}
-      uses: salesforcecli/github-workflows/.github/actions/prNotification@805971e8a839922a04ee328b6bae60894bfc81c4 # main
+      uses: salesforcecli/github-workflows/.github/actions/prNotification@5bb4ac8bb990c61c3e8cc9f2eb1c058a791b3884 # main

--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -48,7 +48,7 @@ jobs:
           go test ./... -count=1
 
       - name: Open draft PR
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
           branch: auto/regen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+      - uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062 # v5.0.0
         with:
           token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary

Applies the three action updates listed in the Renovate dependency dashboard's "Awaiting Schedule" section, so we don't wait on Renovate's schedule.

| Action | From | To |
| --- | --- | --- |
| salesforcecli/github-workflows (prNotification) | digest `805971e` | digest `5bb4ac8` (tracks `main`) |
| googleapis/release-please-action | v4 | **v5.0.0** |
| peter-evans/create-pull-request | v6 | **v8.1.1** |

All actions remain SHA-pinned with a version comment.

## Breaking-change handling

Both majors were checked against their release notes:

- **release-please-action v5.0.0** — sole documented breaking change is the Node 24 runtime bump. Inputs in use (`token`, `config-file`, `manifest-file`) are unchanged.
- **create-pull-request v8.1.1** (from v6, spanning v7) — v8's change is the Node 24 runtime; the inputs in use (`token`, `branch`, `draft`, `title`, `commit-message`, `body`, `labels`) are long-standing and unchanged.

Node 24 is supported on GitHub-hosted `ubuntu-latest`, so no runner changes are needed.

## Verification

- All three workflow YAML files validated as well-formed.
- None of these actions run on a normal PR (`release.yml` = push to main; `regen.yml` = schedule/dispatch; `notify-slack-on-pr-open.yml` = PR-opened event), so they aren't exercised by this PR's CI — verified against release notes rather than a live run, same as the earlier Actions PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)