### PR TITLE
ci: pin release-please-action to its commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062 # v5.0.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary

Follow-up to #114. Renovate's dashboard kept proposing `chore(deps): update googleapis/release-please-action digest to 45996ed`, which surfaced a subtlety in the pin #114 introduced.

`googleapis/release-please-action` uses an **annotated** `v5` tag. In #114 I resolved it via `git/ref/tags/v5`, which returns the SHA of the *tag object* (`0dfd8538`), not the commit it points to. This repins to the actual **v5.0.0 release commit** `45996ed` — both `v5` and `v5.0.0` dereference to it.

## This was not breaking

To be clear: the merged #114 pin **works at runtime**. The runner dereferences the tag object automatically, and the release-please job ran green on the #114 merge commit ([run](https://github.com/gr4vy/gr4vy-cli/actions/workflows/release.yml)). So no production impact.

The reason to fix it anyway:
1. **Convention** — every other action in this repo is pinned to a commit SHA; a tag-object SHA is the odd one out, and SHA-pin security scanners (zizmor/ratchet) expect commit SHAs.
2. **Renovate churn** — Renovate compares against the commit digest, so it re-adds this entry to the dashboard every cycle until the pin matches.

## Verification

- `45996ed` confirmed as a real commit (`chore(main): release 5.0.0`), not a tag object.
- Audited every other pin from #113/#114 — all six resolve to real commits; this was the only tag-object pin.
- `release.yml` YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)