### PR TITLE
feat: identify CLI traffic with a User-Agent product token

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/gr4vy/gr4vy-cli/internal/config"
 	"github.com/gr4vy/gr4vy-cli/internal/secret"
+	"github.com/gr4vy/gr4vy-cli/internal/useragent"
 )
 
 // Credential-related environment variables.
@@ -28,6 +30,9 @@ const (
 
 // defaultTokenTTL is the lifetime, in seconds, of JWTs minted for API calls.
 const defaultTokenTTL = 3600
+
+// sdkClientTimeout mirrors the default gr4vy-go applies when no client is set.
+const sdkClientTimeout = 60 * time.Second
 
 // TokenProvider yields a valid bearer token for an API call, minting or
 // refreshing as needed.
@@ -86,6 +91,9 @@ func NewClient(r config.Resolved, p TokenProvider, timeout time.Duration) (*gr4v
 		gr4vygo.WithID(r.Profile.ID),
 		gr4vygo.WithServer(serverFor(r.Profile.Environment)),
 		gr4vygo.WithSecuritySource(SecuritySource(p)),
+		// Supplying a client opts out of the SDK's default, so carry its 60s
+		// timeout over. WithTimeout, when set, still applies on top.
+		gr4vygo.WithClient(useragent.WrapClient(&http.Client{Timeout: sdkClientTimeout})),
 	}
 	if r.Profile.MerchantAccountID != "" {
 		opts = append(opts, gr4vygo.WithMerchantAccountID(r.Profile.MerchantAccountID))

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gr4vy/gr4vy-cli/internal/config"
 	"github.com/gr4vy/gr4vy-cli/internal/secret"
+	"github.com/gr4vy/gr4vy-cli/internal/useragent"
 )
 
 // sessionPath is the (internal, unpublished) endpoint for email/password
@@ -212,6 +213,9 @@ func doSession(ctx context.Context, client *http.Client, method, host string, bo
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")
+	// This path bypasses the SDK, so net/http would otherwise send its
+	// anonymous "Go-http-client/1.1" default.
+	req.Header.Set("User-Agent", useragent.String())
 	if bearer != "" {
 		req.Header.Set("Authorization", "Bearer "+bearer)
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gr4vy/gr4vy-cli/internal/clierr"
 	"github.com/gr4vy/gr4vy-cli/internal/commands"
 	_ "github.com/gr4vy/gr4vy-cli/internal/commands/generated" // registers generated API commands
+	"github.com/gr4vy/gr4vy-cli/internal/useragent"
 )
 
 // BuildInfo carries version metadata stamped into the binary at build time.
@@ -29,6 +30,7 @@ var build BuildInfo
 // process exit code.
 func Execute(bi BuildInfo) {
 	build = bi
+	useragent.SetVersion(bi.Version)
 	root := NewRootCmd()
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "error: "+clierr.FormatError(err))

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -1,0 +1,60 @@
+// Package useragent identifies CLI traffic on the wire. Requests made through
+// the embedded gr4vy-go SDK are otherwise indistinguishable from any other Go
+// SDK integration, so the CLI prepends its own product token to the SDK's
+// User-Agent.
+//
+// It is a leaf package (net/http only) so both internal/auth and internal/cli
+// can depend on it.
+package useragent
+
+import (
+	"net/http"
+	"strings"
+)
+
+// version is the CLI version, set once from main's build metadata.
+var version = "dev"
+
+// SetVersion records the running CLI version. It is called by cli.Execute
+// before any command runs.
+func SetVersion(v string) {
+	if v != "" {
+		version = v
+	}
+}
+
+// String is the CLI's product token, e.g. "gr4vy-cli/1.17.0".
+func String() string {
+	return "gr4vy-cli/" + version
+}
+
+// doer is the subset of *http.Client the SDK needs. It matches gr4vy-go's
+// exported HTTPClient interface structurally, so a Client satisfies both.
+type doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client wraps a doer and prepends the CLI's product token to every outgoing
+// User-Agent.
+type Client struct {
+	inner doer
+}
+
+// WrapClient returns inner with CLI identification applied to each request.
+func WrapClient(inner doer) Client {
+	return Client{inner: inner}
+}
+
+// Do prepends the CLI product token to the User-Agent set by the SDK, keeping
+// the SDK and generator versions that follow it. Ordering matches RFC 9110:
+// most significant product first.
+//
+// Do is idempotent. The SDK's retry loop reuses a single *http.Request across
+// attempts, so an unconditional prepend would compound the token on retries.
+func (c Client) Do(req *http.Request) (*http.Response, error) {
+	prefix := String()
+	if ua := req.Header.Get("User-Agent"); !strings.HasPrefix(ua, prefix) {
+		req.Header.Set("User-Agent", strings.TrimSpace(prefix+" "+ua))
+	}
+	return c.inner.Do(req)
+}

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -1,0 +1,98 @@
+package useragent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// recorder captures the User-Agent it is asked to send.
+type recorder struct {
+	seen  []string
+	calls int
+}
+
+func (r *recorder) Do(req *http.Request) (*http.Response, error) {
+	r.calls++
+	r.seen = append(r.seen, req.Header.Get("User-Agent"))
+	return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+}
+
+func withVersion(t *testing.T, v string) {
+	t.Helper()
+	prev := version
+	version = v
+	t.Cleanup(func() { version = prev })
+}
+
+func TestStringUsesVersion(t *testing.T) {
+	withVersion(t, "1.17.0")
+	if got := String(); got != "gr4vy-cli/1.17.0" {
+		t.Errorf("String()=%q", got)
+	}
+}
+
+func TestSetVersionIgnoresEmpty(t *testing.T) {
+	withVersion(t, "1.2.3")
+	SetVersion("")
+	if got := String(); got != "gr4vy-cli/1.2.3" {
+		t.Errorf("empty SetVersion overwrote version: %q", got)
+	}
+}
+
+func TestDoPrependsToSDKUserAgent(t *testing.T) {
+	withVersion(t, "1.17.0")
+	rec := &recorder{}
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/", nil)
+	req.Header.Set("User-Agent", "speakeasy-sdk/go 1.13.0 2.927.0 1.0.0 github.com/gr4vy/gr4vy-go")
+
+	if _, err := WrapClient(rec).Do(req); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "gr4vy-cli/1.17.0 speakeasy-sdk/go 1.13.0 2.927.0 1.0.0 github.com/gr4vy/gr4vy-go"
+	if rec.seen[0] != want {
+		t.Errorf("User-Agent=%q want %q", rec.seen[0], want)
+	}
+}
+
+func TestDoSetsUserAgentWhenAbsent(t *testing.T) {
+	withVersion(t, "1.17.0")
+	rec := &recorder{}
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/", nil)
+	req.Header.Del("User-Agent")
+
+	if _, err := WrapClient(rec).Do(req); err != nil {
+		t.Fatal(err)
+	}
+
+	if rec.seen[0] != "gr4vy-cli/1.17.0" {
+		t.Errorf("User-Agent=%q", rec.seen[0])
+	}
+}
+
+// The SDK's retry loop reuses one *http.Request across attempts, so Do must not
+// compound the product token.
+func TestDoIsIdempotentAcrossRetries(t *testing.T) {
+	withVersion(t, "1.17.0")
+	rec := &recorder{}
+	c := WrapClient(rec)
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/", nil)
+	req.Header.Set("User-Agent", "speakeasy-sdk/go 1.13.0 2.927.0 1.0.0 github.com/gr4vy/gr4vy-go")
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.Do(req); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if rec.calls != 3 {
+		t.Fatalf("calls=%d want 3", rec.calls)
+	}
+	want := "gr4vy-cli/1.17.0 speakeasy-sdk/go 1.13.0 2.927.0 1.0.0 github.com/gr4vy/gr4vy-go"
+	for i, got := range rec.seen {
+		if got != want {
+			t.Errorf("attempt %d User-Agent=%q want %q", i, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

CLI traffic is currently invisible on the wire — there is no way to tell a `gr4vy` command from any other Go integration:

- **API commands** go through the embedded gr4vy-go SDK, which sends its stock token, identical to a hand-written Go SDK integration:
  ```
  speakeasy-sdk/go 1.13.0 2.927.0 1.0.0 github.com/gr4vy/gr4vy-go
  ```
- **`login` / `logout`** bypass the SDK entirely (`internal/auth/login.go` hand-rolls requests to `/auth/sessions`) and set no User-Agent at all, so `net/http` supplies its anonymous default:
  ```
  Go-http-client/1.1
  ```

The CLI already knows its own version — stamped via ldflags into `main.version` and carried in `cli.BuildInfo` — it just never put it on the wire.

## Approach

gr4vy-go exposes no `WithUserAgent` option, and keeps both its `UserAgent` field (`internal/config`) and its request hooks (`internal/hooks`) in internal packages, so neither is reachable from this repo. The one consumer-side lever is `WithClient(HTTPClient)`.

The SDK sets its User-Agent *before* calling `Client.Do(req)`, so a wrapping client sees the header and can prepend to it. New leaf package `internal/useragent` does exactly that:

```
gr4vy-cli/1.18.0 speakeasy-sdk/go 1.13.0 2.927.0 1.0.0 github.com/gr4vy/gr4vy-go
```

Ordering follows RFC 9110 — most significant product token first — so SDK and generator versions are preserved rather than replaced, and CLI traffic becomes greppable in access logs.

`doSession` gets a plain `Header.Set` to cover the login/logout path.

## Verified

Confirmed end-to-end against an `httptest` server driving a real SDK call (scratch test, not committed) — the combined header arrives at the server:

```
WIRE User-Agent: "gr4vy-cli/9.9.9 speakeasy-sdk/go 1.13.0 2.927.0 1.0.0 github.com/gr4vy/gr4vy-go"
```

`make lint` and `go test ./...` pass.

## Notes for review

Three details that are load-bearing:

1. **The wrapper is idempotent.** The SDK's retry loop reuses a single `*http.Request` across attempts (only the body is recreated via `GetBody`), so an unconditional prepend would compound to `gr4vy-cli/x gr4vy-cli/x speakeasy-sdk/go …` on retry. Guarded with a `HasPrefix` check and covered by `TestDoIsIdempotentAcrossRetries`.

2. **The 60s timeout is carried over explicitly.** `gr4vygo.New()` only defaults its client when `Client` is nil, so passing `WithClient` opts out of that default. `sdkClientTimeout` mirrors it. The existing `WithTimeout` option is a separate field and still applies on top.

3. **The JWT `iss` claim is unaffected.** gr4vy-go derives the token issuer from a fresh `New()` with no options, so it always reads the stock SDK string regardless of the injected client. The wire header and the token issuer are fully decoupled — no change to token validation.

`internal/useragent` deliberately depends on `net/http` only (it declares its own one-method `doer` interface, which satisfies `gr4vygo.HTTPClient` structurally) so both `internal/auth` and `internal/cli` can import it without a cycle.